### PR TITLE
Fix orchestrator reliability, error handling, and deployment pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
-.PHONY: build run test clean docker-build docker-push lint
+.PHONY: build run test clean docker-build docker-build-local docker-push docker-deploy lint db-status setup-aws deps
 
 BINARY := backflow
 PKG := github.com/backflow-labs/backflow
 GOFLAGS := -trimpath
 export PATH := $(HOME)/.local/go/bin:$(HOME)/go/bin:$(PATH)
+
+DOCKER ?= docker
+
+# Helper to source .env before a command
+ENV = if [ -f .env ]; then set -a; . ./.env; set +a; fi
 
 build:
 	go build $(GOFLAGS) -o bin/$(BINARY) ./cmd/backflow
@@ -21,21 +26,37 @@ clean:
 	rm -rf bin/
 
 docker-build:
-	docker buildx build \
+	$(DOCKER) buildx build \
 		--platform linux/amd64,linux/arm64 \
 		-t backflow-agent \
 		docker/
 
 docker-build-local:
-	docker build -t backflow-agent docker/
+	$(DOCKER) build -t backflow-agent docker/
 
 docker-push:
 	@echo "Usage: make docker-push REGISTRY=<ecr-uri>"
-	docker tag backflow-agent $(REGISTRY):latest
-	docker push $(REGISTRY):latest
+	$(DOCKER) tag backflow-agent $(REGISTRY):latest
+	$(DOCKER) push $(REGISTRY):latest
+
+docker-deploy:
+	@$(ENV); \
+	ACCOUNT_ID=$$(aws sts get-caller-identity --query Account --output text) && \
+	REGION=$${AWS_REGION:-us-east-1} && \
+	ECR=$$ACCOUNT_ID.dkr.ecr.$$REGION.amazonaws.com && \
+	aws ecr get-login-password --region $$REGION | $(DOCKER) login --username AWS --password-stdin $$ECR && \
+	$(DOCKER) buildx build \
+		--platform linux/amd64,linux/arm64 \
+		-t $$ECR/backflow-agent:latest \
+		--push \
+		docker/ && \
+	echo "Pushed to $$ECR/backflow-agent:latest"
+
+db-status:
+	@bash scripts/db-status.sh
 
 setup-aws:
-	bash scripts/setup-aws.sh
+	@$(ENV); bash scripts/setup-aws.sh
 
 deps:
 	go mod tidy

--- a/README.md
+++ b/README.md
@@ -1,0 +1,199 @@
+# Backflow
+
+Background agent orchestrator that spins up ephemeral Docker containers on AWS EC2 spot instances to run Claude Code against coding tasks.
+
+## How It Works
+
+1. You POST a task (repo URL + prompt) to the REST API
+2. The orchestrator provisions an EC2 spot instance (if needed)
+3. A Docker container clones the repo, runs Claude Code, commits, pushes, and optionally creates a PR
+4. Webhook notifications fire on lifecycle events (completed, failed, needs input)
+
+## Auth Modes
+
+- **`api_key`** (default) — Uses an Anthropic API key. Supports multiple concurrent agents. Token costs apply.
+- **`max_subscription`** — Uses a Claude Max subscription. Strictly one agent at a time. Flat monthly fee.
+
+## Setup
+
+### Prerequisites
+
+- Go 1.24+
+- Docker
+- AWS CLI (authenticated)
+- An AWS account with EC2, ECR, SSM, and IAM access
+
+### 1. AWS Infrastructure
+
+```bash
+make setup-aws
+```
+
+Creates: ECR repo, IAM role (EC2 + SSM + ECR), security group (outbound-only), launch template with latest Amazon Linux 2023 AMI.
+
+Note the `BACKFLOW_LAUNCH_TEMPLATE_ID` in the output.
+
+### 2. Build & Push Agent Image
+
+```bash
+make docker-deploy
+# or if docker requires sudo:
+make docker-deploy DOCKER="sudo docker"
+```
+
+### 3. Configure
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with your values:
+
+```
+BACKFLOW_AUTH_MODE=api_key
+ANTHROPIC_API_KEY=sk-ant-...
+GITHUB_TOKEN=ghp_...
+AWS_REGION=us-east-1
+BACKFLOW_LAUNCH_TEMPLATE_ID=lt-...
+```
+
+### 4. Run
+
+```bash
+make run
+```
+
+Server starts on `:8080` by default.
+
+## Usage
+
+### Create a Task
+
+```bash
+./scripts/create-task.sh https://github.com/org/repo "Fix the login bug" --pr
+```
+
+Or with more options:
+
+```bash
+./scripts/create-task.sh https://github.com/org/repo "Add unit tests" \
+  --pr --pr-title "Add tests" \
+  --budget 15 --model claude-sonnet-4-6 \
+  --context "Focus on the auth module"
+```
+
+### API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/tasks` | Create a task |
+| GET | `/api/v1/tasks` | List tasks (filters: `?status=`, `?limit=`, `?offset=`) |
+| GET | `/api/v1/tasks/{id}` | Get a task |
+| DELETE | `/api/v1/tasks/{id}` | Cancel/delete a task |
+| GET | `/api/v1/tasks/{id}/logs` | Get agent container logs (`?tail=100`) |
+| GET | `/api/v1/health` | Health check |
+
+### Check Status
+
+```bash
+# DB dump
+make db-status
+
+# Task logs
+curl http://localhost:8080/api/v1/tasks/bf_01KK.../logs
+
+# SSH into agent VM (no SSH keys needed)
+aws ssm start-session --target i-0abc...
+```
+
+## Architecture
+
+```
+┌─────────┐     ┌──────────────────────────────────────┐
+│  Client  │────▶│  Backflow Server (:8080)              │
+└─────────┘     │  ├── REST API (chi)                   │
+                │  ├── Orchestrator (5s poll loop)       │
+                │  │   ├── Scaler (EC2 spot instances)   │
+                │  │   ├── Docker (containers via SSM)   │
+                │  │   └── Spot handler (re-queue)       │
+                │  ├── SQLite store (WAL mode)           │
+                │  └── Webhook notifier                  │
+                └──────────────┬───────────────────────┘
+                               │ SSM
+                ┌──────────────▼───────────────────────┐
+                │  EC2 Spot Instance (t4g.medium)       │
+                │  ├── Docker container: backflow-agent │
+                │  │   ├── Clone repo                   │
+                │  │   ├── Run Claude Code              │
+                │  │   ├── Commit + push                │
+                │  │   └── Create PR                    │
+                │  └── (up to 4 containers per instance)│
+                └──────────────────────────────────────┘
+```
+
+## Instance Lifecycle
+
+1. Task submitted → orchestrator checks for capacity
+2. No capacity → scaler launches a spot instance (saved as `pending`)
+3. Scaler polls EC2 until instance is running, SSM is online, and Docker + agent image are ready → marked `running`
+4. Orchestrator dispatches task → runs container via SSM
+5. Container finishes → orchestrator captures status, fires webhook
+6. Instance idle for 5 minutes → scaler terminates it
+
+Spot interruptions: instances are re-checked, tasks on interrupted instances are re-queued as `pending` with incremented retry count.
+
+## Webhooks
+
+Set `BACKFLOW_WEBHOOK_URL` in `.env`. Receives POST with:
+
+```json
+{
+  "event": "task.completed",
+  "task_id": "bf_01KK...",
+  "repo_url": "https://github.com/org/repo",
+  "prompt": "Fix the bug",
+  "message": "",
+  "agent_log_tail": "last 20 lines...",
+  "timestamp": "2026-03-13T22:00:00Z"
+}
+```
+
+Events: `task.created`, `task.running`, `task.completed`, `task.failed`, `task.needs_input`, `task.interrupted`
+
+Filter with `BACKFLOW_WEBHOOK_EVENTS=task.completed,task.failed`.
+
+## Config Reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BACKFLOW_AUTH_MODE` | `api_key` | `api_key` or `max_subscription` |
+| `ANTHROPIC_API_KEY` | | Required for `api_key` mode |
+| `CLAUDE_CREDENTIALS_PATH` | | Path to `~/.claude/` for `max_subscription` mode |
+| `GITHUB_TOKEN` | | For cloning private repos and creating PRs |
+| `BACKFLOW_LISTEN_ADDR` | `:8080` | Server listen address |
+| `BACKFLOW_DB_PATH` | `backflow.db` | SQLite database path |
+| `AWS_REGION` | `us-east-1` | AWS region |
+| `BACKFLOW_INSTANCE_TYPE` | `t4g.medium` | EC2 instance type |
+| `BACKFLOW_LAUNCH_TEMPLATE_ID` | | Launch template from `setup-aws` |
+| `BACKFLOW_MAX_INSTANCES` | `5` | Max EC2 instances |
+| `BACKFLOW_CONTAINERS_PER_INSTANCE` | `4` | Max containers per instance |
+| `BACKFLOW_DEFAULT_MODEL` | `claude-sonnet-4-6` | Default Claude model |
+| `BACKFLOW_DEFAULT_MAX_BUDGET` | `10` | Default max budget (USD) |
+| `BACKFLOW_DEFAULT_MAX_RUNTIME_MIN` | `30` | Default max runtime (minutes) |
+| `BACKFLOW_DEFAULT_MAX_TURNS` | `200` | Default max conversation turns |
+| `BACKFLOW_WEBHOOK_URL` | | Webhook endpoint |
+| `BACKFLOW_WEBHOOK_EVENTS` | all | Comma-separated event filter |
+| `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator poll interval |
+| `DOCKER` | `docker` | Docker command (set to `sudo docker` if needed) |
+
+## Development
+
+```bash
+make build          # Build server binary
+make run            # Build + run (sources .env)
+make test           # Run tests
+make lint           # go vet
+make db-status      # Dump database state
+make docker-deploy  # Build + push agent image to ECR
+make setup-aws      # Create AWS infrastructure
+```

--- a/cmd/backflow/main.go
+++ b/cmd/backflow/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:         cfg.ListenAddr,
-		Handler:      api.NewServer(db, cfg),
+		Handler:      api.NewServer(db, cfg, orch.Docker()),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  60 * time.Second,

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -73,6 +73,7 @@ fi
 # --- GitHub auth ---
 if [ -n "${GITHUB_TOKEN:-}" ]; then
     echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null || true
+    gh auth setup-git 2>/dev/null || true
 fi
 
 # --- Auth mode setup ---
@@ -128,6 +129,7 @@ while [ $ATTEMPT -lt "$MAX_RETRIES" ]; do
     fi
 
     echo "==> Claude Code exited with code ${CLAUDE_EXIT} (attempt ${ATTEMPT})"
+    echo "$CLAUDE_OUTPUT" | tail -30
 
     if [ $ATTEMPT -lt "$MAX_RETRIES" ]; then
         # Add error context to prompt for retry

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -14,13 +15,19 @@ import (
 	"github.com/backflow-labs/backflow/internal/store"
 )
 
+// LogFetcher retrieves container logs for a running task.
+type LogFetcher interface {
+	GetLogs(ctx context.Context, instanceID, containerID string, tail int) (string, error)
+}
+
 type Handlers struct {
 	store  store.Store
 	config *config.Config
+	logs   LogFetcher
 }
 
-func NewHandlers(s store.Store, cfg *config.Config) *Handlers {
-	return &Handlers{store: s, config: cfg}
+func NewHandlers(s store.Store, cfg *config.Config, logs LogFetcher) *Handlers {
+	return &Handlers{store: s, config: cfg, logs: logs}
 }
 
 func (h *Handlers) CreateTask(w http.ResponseWriter, r *http.Request) {
@@ -153,11 +160,33 @@ func (h *Handlers) GetTaskLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Logs will be fetched from the container via SSM in a future iteration.
-	// For now, return a placeholder.
+	if task.InstanceID == "" || task.ContainerID == "" {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		msg := "status: " + string(task.Status) + "\n"
+		if task.Error != "" {
+			msg += "error: " + task.Error + "\n"
+		}
+		w.Write([]byte(msg))
+		return
+	}
+
+	tail := 100
+	if t := r.URL.Query().Get("tail"); t != "" {
+		if n, err := strconv.Atoi(t); err == nil && n > 0 {
+			tail = n
+		}
+	}
+
+	logs, err := h.logs.GetLogs(r.Context(), task.InstanceID, task.ContainerID, tail)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch logs: "+err.Error())
+		return
+	}
+
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("logs not yet available for task " + id + "\n"))
+	w.Write([]byte(logs))
 }
 
 func (h *Handlers) HealthCheck(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,12 @@ import (
 	"github.com/backflow-labs/backflow/internal/config"
 	"github.com/backflow-labs/backflow/internal/store"
 )
+
+type noopLogFetcher struct{}
+
+func (noopLogFetcher) GetLogs(_ context.Context, _, _ string, _ int) (string, error) {
+	return "test logs\n", nil
+}
 
 func testServer(t *testing.T) http.Handler {
 	t.Helper()
@@ -36,7 +43,7 @@ func testServer(t *testing.T) http.Handler {
 		DefaultMaxTurns:   200,
 	}
 
-	return NewServer(s, cfg)
+	return NewServer(s, cfg, noopLogFetcher{})
 }
 
 func TestHealthCheck(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,7 +10,7 @@ import (
 	"github.com/backflow-labs/backflow/internal/store"
 )
 
-func NewServer(s store.Store, cfg *config.Config) http.Handler {
+func NewServer(s store.Store, cfg *config.Config, logs LogFetcher) http.Handler {
 	r := chi.NewRouter()
 
 	r.Use(middleware.RequestID)
@@ -19,7 +19,7 @@ func NewServer(s store.Store, cfg *config.Config) http.Handler {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.SetHeader("Content-Type", "application/json"))
 
-	h := NewHandlers(s, cfg)
+	h := NewHandlers(s, cfg, logs)
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Get("/health", h.HealthCheck)

--- a/internal/orchestrator/docker.go
+++ b/internal/orchestrator/docker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -96,7 +97,7 @@ func (m *DockerManager) RunAgent(ctx context.Context, instance *models.Instance,
 	}
 
 	cmd := fmt.Sprintf(
-		"docker run -d --cpus=1 --memory=3g %s %s backflow-agent 2>&1 | head -1",
+		"docker run -d --cpus=1 --memory=3g %s %s backflow-agent",
 		volumeFlags,
 		strings.Join(envFlags, " "),
 	)
@@ -109,6 +110,12 @@ func (m *DockerManager) RunAgent(ctx context.Context, instance *models.Instance,
 	containerID := strings.TrimSpace(output)
 	if containerID == "" {
 		return "", fmt.Errorf("empty container ID returned")
+	}
+
+	// Docker container IDs are 64-char hex strings; reject anything else
+	// (e.g. error messages captured via 2>&1)
+	if !isHexString(containerID) {
+		return "", fmt.Errorf("docker run failed: %s", containerID)
 	}
 
 	log.Debug().Str("container", containerID[:12]).Str("instance", instance.InstanceID).Msg("started agent container")
@@ -192,6 +199,10 @@ func (m *DockerManager) GetLogs(ctx context.Context, instanceID, containerID str
 }
 
 func (m *DockerManager) runSSMCommand(ctx context.Context, instanceID, command string) (string, error) {
+	if err := m.ensureClient(ctx); err != nil {
+		return "", err
+	}
+
 	input := &ssm.SendCommandInput{
 		InstanceIds:  []string{instanceID},
 		DocumentName: aws.String("AWS-RunShellScript"),
@@ -214,7 +225,21 @@ func (m *DockerManager) runSSMCommand(ctx context.Context, instanceID, command s
 		InstanceId: aws.String(instanceID),
 	}
 
-	if err := waiter.Wait(ctx, getOutput, 60); err != nil {
+	if err := waiter.Wait(ctx, getOutput, 5*time.Minute); err != nil {
+		// Fetch output even on failure to get stderr/diagnostics
+		if out, getErr := m.ssmClient.GetCommandInvocation(ctx, getOutput); getErr == nil {
+			stderr := strings.TrimSpace(aws.ToString(out.StandardErrorContent))
+			stdout := strings.TrimSpace(aws.ToString(out.StandardOutputContent))
+			status := string(out.Status)
+			detail := stderr
+			if detail == "" {
+				detail = stdout
+			}
+			if detail != "" {
+				return "", fmt.Errorf("ssm command failed (status=%s): %s", status, detail)
+			}
+			return "", fmt.Errorf("ssm command failed (status=%s): %w", status, err)
+		}
 		return "", fmt.Errorf("wait for command: %w", err)
 	}
 
@@ -224,6 +249,18 @@ func (m *DockerManager) runSSMCommand(ctx context.Context, instanceID, command s
 	}
 
 	return aws.ToString(out.StandardOutputContent), nil
+}
+
+func isHexString(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
 }
 
 func shellEscape(s string) string {

--- a/internal/orchestrator/ec2.go
+++ b/internal/orchestrator/ec2.go
@@ -40,9 +40,8 @@ func (m *EC2Manager) LaunchSpotInstance(ctx context.Context) (string, error) {
 	}
 
 	input := &ec2.RunInstancesInput{
-		MinCount:     aws.Int32(1),
-		MaxCount:     aws.Int32(1),
-		InstanceType: types.InstanceType(m.config.InstanceType),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
 		InstanceMarketOptions: &types.InstanceMarketOptionsRequest{
 			MarketType: types.MarketTypeSpot,
 			SpotOptions: &types.SpotMarketOptions{
@@ -50,7 +49,18 @@ func (m *EC2Manager) LaunchSpotInstance(ctx context.Context) (string, error) {
 				InstanceInterruptionBehavior: types.InstanceInterruptionBehaviorTerminate,
 			},
 		},
-		TagSpecifications: []types.TagSpecification{
+	}
+
+	if m.config.LaunchTemplateID != "" {
+		// Let the launch template provide ImageId, InstanceType, tags, etc.
+		input.LaunchTemplate = &types.LaunchTemplateSpecification{
+			LaunchTemplateId: aws.String(m.config.LaunchTemplateID),
+			Version:          aws.String("$Latest"),
+		}
+	} else if m.config.AMI != "" {
+		input.ImageId = aws.String(m.config.AMI)
+		input.InstanceType = types.InstanceType(m.config.InstanceType)
+		input.TagSpecifications = []types.TagSpecification{
 			{
 				ResourceType: types.ResourceTypeInstance,
 				Tags: []types.Tag{
@@ -58,16 +68,7 @@ func (m *EC2Manager) LaunchSpotInstance(ctx context.Context) (string, error) {
 					{Key: aws.String("backflow"), Value: aws.String("true")},
 				},
 			},
-		},
-	}
-
-	if m.config.LaunchTemplateID != "" {
-		input.LaunchTemplate = &types.LaunchTemplateSpecification{
-			LaunchTemplateId: aws.String(m.config.LaunchTemplateID),
-			Version:          aws.String("$Latest"),
 		}
-	} else if m.config.AMI != "" {
-		input.ImageId = aws.String(m.config.AMI)
 	} else {
 		return "", fmt.Errorf("either BACKFLOW_AMI or BACKFLOW_LAUNCH_TEMPLATE_ID must be set")
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -23,23 +23,31 @@ type Orchestrator struct {
 	scaler   *Scaler
 	spot     *SpotHandler
 
-	mu       sync.Mutex
-	running  int
-	stopCh   chan struct{}
+	mu             sync.Mutex
+	running        int
+	stopCh         chan struct{}
+	inspectFailures map[string]int // task ID -> consecutive inspect failure count
 }
 
 func New(s store.Store, cfg *config.Config, notifier notify.Notifier) *Orchestrator {
 	ec2 := NewEC2Manager(cfg)
+	docker := NewDockerManager(cfg)
 	return &Orchestrator{
 		store:    s,
 		config:   cfg,
 		notifier: notifier,
 		ec2:      ec2,
-		docker:   NewDockerManager(cfg),
-		scaler:   NewScaler(s, ec2, cfg),
+		docker:   docker,
+		scaler:   NewScaler(s, ec2, docker, cfg),
 		spot:     NewSpotHandler(s, ec2),
-		stopCh:   make(chan struct{}),
+		stopCh:          make(chan struct{}),
+		inspectFailures: make(map[string]int),
 	}
+}
+
+// Docker returns the DockerManager for use by the API logs endpoint.
+func (o *Orchestrator) Docker() *DockerManager {
+	return o.docker
 }
 
 func (o *Orchestrator) Start(ctx context.Context) {
@@ -203,9 +211,17 @@ func (o *Orchestrator) monitorRunning(ctx context.Context) {
 		// Check container status
 		status, err := o.docker.InspectContainer(ctx, task.InstanceID, task.ContainerID)
 		if err != nil {
-			log.Warn().Err(err).Str("task_id", task.ID).Msg("failed to inspect container")
+			o.inspectFailures[task.ID]++
+			count := o.inspectFailures[task.ID]
+			log.Warn().Err(err).Str("task_id", task.ID).Int("consecutive_failures", count).Msg("failed to inspect container")
+			if count >= 3 {
+				delete(o.inspectFailures, task.ID)
+				o.killTask(ctx, task, fmt.Sprintf("container unreachable after %d inspect failures: %v", count, err))
+			}
 			continue
 		}
+
+		delete(o.inspectFailures, task.ID)
 
 		if status.Done {
 			o.handleCompletion(ctx, task, status)

--- a/internal/orchestrator/scaler.go
+++ b/internal/orchestrator/scaler.go
@@ -2,8 +2,14 @@ package orchestrator
 
 import (
 	"context"
+	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/rs/zerolog/log"
 
 	"github.com/backflow-labs/backflow/internal/config"
@@ -14,31 +20,89 @@ import (
 const idleTimeout = 5 * time.Minute
 
 type Scaler struct {
-	store  store.Store
-	ec2    *EC2Manager
-	config *config.Config
+	store     store.Store
+	ec2       *EC2Manager
+	docker    *DockerManager
+	config    *config.Config
+	ssmClient *ssm.Client
 }
 
-func NewScaler(s store.Store, ec2 *EC2Manager, cfg *config.Config) *Scaler {
-	return &Scaler{store: s, ec2: ec2, config: cfg}
+func NewScaler(s store.Store, ec2 *EC2Manager, docker *DockerManager, cfg *config.Config) *Scaler {
+	return &Scaler{store: s, ec2: ec2, docker: docker, config: cfg}
 }
 
-// Evaluate checks if we need to scale up or down.
+func (s *Scaler) ensureSSMClient(ctx context.Context) error {
+	if s.ssmClient != nil {
+		return nil
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(s.config.AWSRegion))
+	if err != nil {
+		return err
+	}
+	s.ssmClient = ssm.NewFromConfig(cfg)
+	return nil
+}
+
+// isSSMReady checks if the SSM agent on the instance is online and ready.
+func (s *Scaler) isSSMReady(ctx context.Context, instanceID string) bool {
+	if err := s.ensureSSMClient(ctx); err != nil {
+		return false
+	}
+	out, err := s.ssmClient.DescribeInstanceInformation(ctx, &ssm.DescribeInstanceInformationInput{
+		Filters: []ssmtypes.InstanceInformationStringFilter{
+			{Key: aws.String("InstanceIds"), Values: []string{instanceID}},
+		},
+	})
+	if err != nil {
+		return false
+	}
+	for _, info := range out.InstanceInformationList {
+		if info.PingStatus == ssmtypes.PingStatusOnline {
+			return true
+		}
+	}
+	return false
+}
+
+// isDockerReady checks if Docker is running and the agent image is available.
+func (s *Scaler) isDockerReady(ctx context.Context, instanceID string) bool {
+	out, err := s.docker.runSSMCommand(ctx, instanceID, "docker image inspect backflow-agent:latest >/dev/null 2>&1 && echo ready")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) == "ready"
+}
+
+// Evaluate checks pending instances, and scales down idle ones.
 func (s *Scaler) Evaluate(ctx context.Context) {
+	s.reconcilePending(ctx)
+	s.reconcileRunning(ctx)
 	s.scaleDown(ctx)
 }
 
-// RequestScaleUp launches a new instance if under the max.
+// RequestScaleUp launches a new instance if under the max and none are already pending.
 func (s *Scaler) RequestScaleUp(ctx context.Context) {
-	running := models.InstanceStatusRunning
-	instances, err := s.store.ListInstances(ctx, &running)
+	// Count all non-terminated instances (pending + running)
+	allInstances, err := s.store.ListInstances(ctx, nil)
 	if err != nil {
 		log.Error().Err(err).Msg("scaler: failed to list instances")
 		return
 	}
 
-	if len(instances) >= s.config.MaxInstances {
-		log.Debug().Int("running", len(instances)).Int("max", s.config.MaxInstances).Msg("scaler: at max instances")
+	active := 0
+	for _, inst := range allInstances {
+		if inst.Status == models.InstanceStatusPending || inst.Status == models.InstanceStatusRunning {
+			active++
+		}
+		// Don't launch if there's already a pending instance booting up
+		if inst.Status == models.InstanceStatusPending {
+			log.Debug().Str("instance_id", inst.InstanceID).Msg("scaler: instance already pending, skipping scale-up")
+			return
+		}
+	}
+
+	if active >= s.config.MaxInstances {
+		log.Debug().Int("active", active).Int("max", s.config.MaxInstances).Msg("scaler: at max instances")
 		return
 	}
 
@@ -64,6 +128,86 @@ func (s *Scaler) RequestScaleUp(ctx context.Context) {
 	}
 
 	log.Info().Str("instance_id", instanceID).Msg("scaler: launched new instance")
+}
+
+// reconcilePending checks if pending instances have become running (or failed).
+func (s *Scaler) reconcilePending(ctx context.Context) {
+	pending := models.InstanceStatusPending
+	instances, err := s.store.ListInstances(ctx, &pending)
+	if err != nil {
+		return
+	}
+
+	for _, inst := range instances {
+		ec2Inst, err := s.ec2.DescribeInstance(ctx, inst.InstanceID)
+		if err != nil {
+			// If instance not found, mark terminated
+			log.Warn().Err(err).Str("instance_id", inst.InstanceID).Msg("scaler: failed to describe pending instance")
+			if time.Since(inst.CreatedAt) > 5*time.Minute {
+				inst.Status = models.InstanceStatusTerminated
+				s.store.UpdateInstance(ctx, inst)
+			}
+			continue
+		}
+
+		switch ec2Inst.State.Name {
+		case types.InstanceStateNameRunning:
+			// EC2 is running, but wait for SSM + Docker before accepting tasks
+			if !s.isSSMReady(ctx, inst.InstanceID) {
+				log.Debug().Str("instance_id", inst.InstanceID).Msg("scaler: instance running but SSM not ready yet")
+				break
+			}
+			if !s.isDockerReady(ctx, inst.InstanceID) {
+				log.Debug().Str("instance_id", inst.InstanceID).Msg("scaler: instance running but Docker/image not ready yet")
+				break
+			}
+			inst.Status = models.InstanceStatusRunning
+			if ec2Inst.PrivateIpAddress != nil {
+				inst.PrivateIP = *ec2Inst.PrivateIpAddress
+			}
+			if ec2Inst.Placement != nil && ec2Inst.Placement.AvailabilityZone != nil {
+				inst.AvailabilityZone = *ec2Inst.Placement.AvailabilityZone
+			}
+			s.store.UpdateInstance(ctx, inst)
+			log.Info().Str("instance_id", inst.InstanceID).Str("ip", inst.PrivateIP).Msg("scaler: instance ready")
+
+		case types.InstanceStateNameTerminated, types.InstanceStateNameShuttingDown:
+			inst.Status = models.InstanceStatusTerminated
+			s.store.UpdateInstance(ctx, inst)
+			log.Warn().Str("instance_id", inst.InstanceID).Msg("scaler: pending instance terminated")
+
+		default:
+			// Still pending, do nothing
+		}
+	}
+}
+
+// reconcileRunning detects running instances that were terminated externally
+// (e.g. spot interruption not caught by SpotHandler, manual termination).
+func (s *Scaler) reconcileRunning(ctx context.Context) {
+	running := models.InstanceStatusRunning
+	instances, err := s.store.ListInstances(ctx, &running)
+	if err != nil {
+		return
+	}
+
+	for _, inst := range instances {
+		ec2Inst, err := s.ec2.DescribeInstance(ctx, inst.InstanceID)
+		if err != nil {
+			log.Warn().Err(err).Str("instance_id", inst.InstanceID).Msg("scaler: failed to describe running instance, marking terminated")
+			inst.Status = models.InstanceStatusTerminated
+			inst.RunningContainers = 0
+			s.store.UpdateInstance(ctx, inst)
+			continue
+		}
+
+		if ec2Inst.State.Name == types.InstanceStateNameTerminated || ec2Inst.State.Name == types.InstanceStateNameShuttingDown {
+			log.Warn().Str("instance_id", inst.InstanceID).Str("ec2_state", string(ec2Inst.State.Name)).Msg("scaler: running instance was terminated externally")
+			inst.Status = models.InstanceStatusTerminated
+			inst.RunningContainers = 0
+			s.store.UpdateInstance(ctx, inst)
+		}
+	}
 }
 
 func (s *Scaler) scaleDown(ctx context.Context) {

--- a/scripts/db-status.sh
+++ b/scripts/db-status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB="${BACKFLOW_DB_PATH:-backflow.db}"
+
+if [ ! -f "$DB" ]; then
+    echo "Database not found: $DB"
+    exit 1
+fi
+
+echo "=== Tasks ==="
+sqlite3 -header -column "$DB" "SELECT * FROM tasks ORDER BY created_at DESC;"
+
+echo ""
+echo "=== Task Summary ==="
+sqlite3 -header -column "$DB" "
+    SELECT status, count(*) as count FROM tasks GROUP BY status;
+"
+
+echo ""
+echo "=== Instances ==="
+sqlite3 -header -column "$DB" "
+    SELECT instance_id, instance_type, status, private_ip,
+           running_containers || '/' || max_containers as containers,
+           created_at, updated_at
+    FROM instances ORDER BY created_at DESC;
+"
+
+echo ""
+echo "=== Instance Summary ==="
+sqlite3 -header -column "$DB" "
+    SELECT status, count(*) as count FROM instances GROUP BY status;
+"

--- a/scripts/setup-aws.sh
+++ b/scripts/setup-aws.sh
@@ -11,6 +11,30 @@ SG_NAME="backflow-agent-sg"
 LT_NAME="backflow-agent-lt"
 INSTANCE_TYPE="${BACKFLOW_INSTANCE_TYPE:-t4g.medium}"
 
+# Resolve AMI: use provided value or look up latest Amazon Linux 2023 for the instance arch
+AMI_ID="${BACKFLOW_AMI:-}"
+if [ -z "$AMI_ID" ]; then
+    # t4g = arm64 (Graviton), t3/m5/c5 = x86_64
+    if [[ "$INSTANCE_TYPE" == *g.* ]]; then
+        ARCH="arm64"
+    else
+        ARCH="x86_64"
+    fi
+    echo "==> Looking up latest Amazon Linux 2023 AMI (${ARCH})..."
+    AMI_ID=$(aws ec2 describe-images \
+        --owners amazon \
+        --filters "Name=name,Values=al2023-ami-2023.*-${ARCH}" \
+                  "Name=state,Values=available" \
+        --query 'sort_by(Images, &CreationDate)[-1].ImageId' \
+        --output text \
+        --region "$REGION")
+    if [ -z "$AMI_ID" ] || [ "$AMI_ID" = "None" ]; then
+        echo "ERROR: Could not find Amazon Linux 2023 AMI. Set BACKFLOW_AMI manually." >&2
+        exit 1
+    fi
+fi
+echo "    AMI: ${AMI_ID}"
+
 echo "==> Setting up Backflow infrastructure in ${REGION}"
 
 # --- ECR Repository ---
@@ -122,6 +146,7 @@ if aws ec2 describe-launch-templates \
         --launch-template-name "$LT_NAME" \
         --version-description "Backflow agent updated" \
         --launch-template-data "{
+            \"ImageId\": \"${AMI_ID}\",
             \"InstanceType\": \"${INSTANCE_TYPE}\",
             \"IamInstanceProfile\": {\"Name\": \"${IAM_ROLE}\"},
             \"SecurityGroupIds\": [\"${SG_ID}\"],
@@ -141,6 +166,7 @@ else
         --launch-template-name "$LT_NAME" \
         --version-description "Backflow agent v1" \
         --launch-template-data "{
+            \"ImageId\": \"${AMI_ID}\",
             \"InstanceType\": \"${INSTANCE_TYPE}\",
             \"IamInstanceProfile\": {\"Name\": \"${IAM_ROLE}\"},
             \"SecurityGroupIds\": [\"${SG_ID}\"],

--- a/scripts/user-data.sh
+++ b/scripts/user-data.sh
@@ -25,16 +25,18 @@ if ! systemctl is-active amazon-ssm-agent &>/dev/null; then
     systemctl start amazon-ssm-agent
 fi
 
-# Authenticate with ECR
-REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
-ACCOUNT_ID=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | python3 -c "import sys,json; print(json.load(sys.stdin)['accountId'])")
+# Authenticate with ECR (use IMDSv2 token)
+IMDS_TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+REGION=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/placement/region)
+ACCOUNT_ID=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | python3 -c "import sys,json; print(json.load(sys.stdin)['accountId'])")
 ECR_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
 
 echo "==> Authenticating with ECR (${ECR_URI})..."
 aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "$ECR_URI"
 
-# Pull agent image
+# Pull agent image and tag with short name
 echo "==> Pulling agent image..."
 docker pull "${ECR_URI}/backflow-agent:latest"
+docker tag "${ECR_URI}/backflow-agent:latest" backflow-agent:latest
 
 echo "==> Bootstrap complete at $(date)"


### PR DESCRIPTION
- Fix SSM command error handling: capture stderr on failure for diagnostics instead of opaque "waiter state transitioned to Failure" messages
- Fix container ID validation: reject non-hex output from docker run to prevent error messages from being stored as container IDs
- Fix runSSMCommand nil client panic: ensure SSM client is initialized before use (was crashing when called from Scaler.isDockerReady)
- Add inspect failure tracking: kill tasks after 3 consecutive inspect failures instead of polling forever with a stuck counter
- Add reconcileRunning to scaler: detect instances terminated externally (spot reclamation, manual termination) and update DB state
- Fix user-data.sh: use IMDSv2 token-based metadata calls, tag pulled ECR image as backflow-agent:latest for local Docker references
- Fix docker-deploy: use buildx multi-arch build+push instead of single-arch docker build that mismatched t4g (arm64) instances
- Fix entrypoint.sh: add gh auth setup-git for git push credentials, log Claude Code output on failure for debugging
- Add live container log fetching via SSM to the /tasks/{id}/logs endpoint
- Add README, db-status script, and Makefile improvements