### PR TITLE
Add self_review toggle, default off

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,6 +16,7 @@ PR_TITLE="${PR_TITLE:-}"
 PR_BODY="${PR_BODY:-}"
 CLAUDE_MD="${CLAUDE_MD:-}"
 TASK_CONTEXT="${TASK_CONTEXT:-}"
+SELF_REVIEW="${SELF_REVIEW:-false}"
 MAX_RETRIES="${MAX_RETRIES:-3}"
 
 WORKSPACE="/home/agent/workspace"
@@ -233,7 +234,7 @@ if [ "$CREATE_PR" = "true" ] && [ "$COMPLETE" = "true" ]; then
 fi
 
 # --- Self-review phase ---
-if [ -n "$PR_URL" ]; then
+if [ "$SELF_REVIEW" = "true" ] && [ -n "$PR_URL" ]; then
     echo "==> Starting self-review phase..."
 
     # Cap review budget at 20% of coding budget (minimum $2)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -56,6 +56,7 @@ func (h *Handlers) CreateTask(w http.ResponseWriter, r *http.Request) {
 		MaxRuntimeMin: withDefaultInt(req.MaxRuntimeMin, int(h.config.DefaultMaxRuntime.Minutes())),
 		MaxTurns:      withDefaultInt(req.MaxTurns, h.config.DefaultMaxTurns),
 		CreatePR:      req.CreatePR,
+		SelfReview:    req.SelfReview,
 		PRTitle:       req.PRTitle,
 		PRBody:        req.PRBody,
 		AllowedTools:  req.AllowedTools,

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -23,34 +23,35 @@ func (s TaskStatus) IsTerminal() bool {
 }
 
 type Task struct {
-	ID            string     `json:"id"`
-	Status        TaskStatus `json:"status"`
-	RepoURL       string     `json:"repo_url"`
-	Branch        string     `json:"branch"`
-	TargetBranch  string     `json:"target_branch"`
-	Prompt        string     `json:"prompt"`
-	Context       string     `json:"context,omitempty"`
-	Model         string     `json:"model,omitempty"`
-	Effort        string     `json:"effort,omitempty"`
-	MaxBudgetUSD  float64    `json:"max_budget_usd,omitempty"`
-	MaxRuntimeMin int        `json:"max_runtime_min,omitempty"`
-	MaxTurns      int        `json:"max_turns,omitempty"`
-	CreatePR      bool       `json:"create_pr"`
-	PRTitle       string     `json:"pr_title,omitempty"`
-	PRBody        string     `json:"pr_body,omitempty"`
-	PRURL         string     `json:"pr_url,omitempty"`
-	AllowedTools  []string   `json:"allowed_tools,omitempty"`
-	ClaudeMD      string     `json:"claude_md,omitempty"`
+	ID            string            `json:"id"`
+	Status        TaskStatus        `json:"status"`
+	RepoURL       string            `json:"repo_url"`
+	Branch        string            `json:"branch"`
+	TargetBranch  string            `json:"target_branch"`
+	Prompt        string            `json:"prompt"`
+	Context       string            `json:"context,omitempty"`
+	Model         string            `json:"model,omitempty"`
+	Effort        string            `json:"effort,omitempty"`
+	MaxBudgetUSD  float64           `json:"max_budget_usd,omitempty"`
+	MaxRuntimeMin int               `json:"max_runtime_min,omitempty"`
+	MaxTurns      int               `json:"max_turns,omitempty"`
+	CreatePR      bool              `json:"create_pr"`
+	SelfReview    bool              `json:"self_review"`
+	PRTitle       string            `json:"pr_title,omitempty"`
+	PRBody        string            `json:"pr_body,omitempty"`
+	PRURL         string            `json:"pr_url,omitempty"`
+	AllowedTools  []string          `json:"allowed_tools,omitempty"`
+	ClaudeMD      string            `json:"claude_md,omitempty"`
 	EnvVars       map[string]string `json:"env_vars,omitempty"`
-	InstanceID    string     `json:"instance_id,omitempty"`
-	ContainerID   string     `json:"container_id,omitempty"`
-	RetryCount    int        `json:"retry_count"`
-	CostUSD       float64    `json:"cost_usd,omitempty"`
-	Error         string     `json:"error,omitempty"`
-	CreatedAt     time.Time  `json:"created_at"`
-	UpdatedAt     time.Time  `json:"updated_at"`
-	StartedAt     *time.Time `json:"started_at,omitempty"`
-	CompletedAt   *time.Time `json:"completed_at,omitempty"`
+	InstanceID    string            `json:"instance_id,omitempty"`
+	ContainerID   string            `json:"container_id,omitempty"`
+	RetryCount    int               `json:"retry_count"`
+	CostUSD       float64           `json:"cost_usd,omitempty"`
+	Error         string            `json:"error,omitempty"`
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
+	StartedAt     *time.Time        `json:"started_at,omitempty"`
+	CompletedAt   *time.Time        `json:"completed_at,omitempty"`
 }
 
 // AllowedToolsJSON returns the JSON representation for DB storage.
@@ -84,6 +85,7 @@ type CreateTaskRequest struct {
 	MaxRuntimeMin int               `json:"max_runtime_min,omitempty"`
 	MaxTurns      int               `json:"max_turns,omitempty"`
 	CreatePR      bool              `json:"create_pr"`
+	SelfReview    bool              `json:"self_review"`
 	PRTitle       string            `json:"pr_title,omitempty"`
 	PRBody        string            `json:"pr_body,omitempty"`
 	AllowedTools  []string          `json:"allowed_tools,omitempty"`

--- a/internal/orchestrator/docker.go
+++ b/internal/orchestrator/docker.go
@@ -62,6 +62,7 @@ func (m *DockerManager) RunAgent(ctx context.Context, instance *models.Instance,
 		fmt.Sprintf("-e MAX_BUDGET_USD=%g", task.MaxBudgetUSD),
 		fmt.Sprintf("-e MAX_TURNS=%d", task.MaxTurns),
 		fmt.Sprintf("-e CREATE_PR=%t", task.CreatePR),
+		fmt.Sprintf("-e SELF_REVIEW=%t", task.SelfReview),
 	}
 
 	if task.PRTitle != "" {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -50,6 +50,7 @@ func (s *SQLiteStore) migrate() error {
 		max_runtime_min INTEGER NOT NULL DEFAULT 0,
 		max_turns       INTEGER NOT NULL DEFAULT 0,
 		create_pr       INTEGER NOT NULL DEFAULT 0,
+		self_review     INTEGER NOT NULL DEFAULT 0,
 		pr_title        TEXT NOT NULL DEFAULT '',
 		pr_body         TEXT NOT NULL DEFAULT '',
 		pr_url          TEXT NOT NULL DEFAULT '',
@@ -95,15 +96,15 @@ func (s *SQLiteStore) CreateTask(ctx context.Context, task *models.Task) error {
 		INSERT INTO tasks (
 			id, status, repo_url, branch, target_branch, prompt, context,
 			model, effort, max_budget_usd, max_runtime_min, max_turns,
-			create_pr, pr_title, pr_body, pr_url,
+			create_pr, self_review, pr_title, pr_body, pr_url,
 			allowed_tools, claude_md, env_vars,
 			instance_id, container_id, retry_count, cost_usd, error,
 			created_at, updated_at, started_at, completed_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		task.ID, task.Status, task.RepoURL, task.Branch, task.TargetBranch,
 		task.Prompt, task.Context, task.Model, task.Effort,
 		task.MaxBudgetUSD, task.MaxRuntimeMin, task.MaxTurns,
-		boolToInt(task.CreatePR), task.PRTitle, task.PRBody, task.PRURL,
+		boolToInt(task.CreatePR), boolToInt(task.SelfReview), task.PRTitle, task.PRBody, task.PRURL,
 		task.AllowedToolsJSON(), task.ClaudeMD, task.EnvVarsJSON(),
 		task.InstanceID, task.ContainerID, task.RetryCount, task.CostUSD, task.Error,
 		task.CreatedAt.Format(time.RFC3339), task.UpdatedAt.Format(time.RFC3339),
@@ -116,7 +117,7 @@ func (s *SQLiteStore) GetTask(ctx context.Context, id string) (*models.Task, err
 	row := s.db.QueryRowContext(ctx, `SELECT
 		id, status, repo_url, branch, target_branch, prompt, context,
 		model, effort, max_budget_usd, max_runtime_min, max_turns,
-		create_pr, pr_title, pr_body, pr_url,
+		create_pr, self_review, pr_title, pr_body, pr_url,
 		allowed_tools, claude_md, env_vars,
 		instance_id, container_id, retry_count, cost_usd, error,
 		created_at, updated_at, started_at, completed_at
@@ -125,7 +126,7 @@ func (s *SQLiteStore) GetTask(ctx context.Context, id string) (*models.Task, err
 }
 
 func (s *SQLiteStore) ListTasks(ctx context.Context, filter TaskFilter) ([]*models.Task, error) {
-	query := "SELECT id, status, repo_url, branch, target_branch, prompt, context, model, effort, max_budget_usd, max_runtime_min, max_turns, create_pr, pr_title, pr_body, pr_url, allowed_tools, claude_md, env_vars, instance_id, container_id, retry_count, cost_usd, error, created_at, updated_at, started_at, completed_at FROM tasks"
+	query := "SELECT id, status, repo_url, branch, target_branch, prompt, context, model, effort, max_budget_usd, max_runtime_min, max_turns, create_pr, self_review, pr_title, pr_body, pr_url, allowed_tools, claude_md, env_vars, instance_id, container_id, retry_count, cost_usd, error, created_at, updated_at, started_at, completed_at FROM tasks"
 	var args []any
 	var where []string
 
@@ -167,7 +168,7 @@ func (s *SQLiteStore) UpdateTask(ctx context.Context, task *models.Task) error {
 		UPDATE tasks SET
 			status=?, repo_url=?, branch=?, target_branch=?, prompt=?, context=?,
 			model=?, effort=?, max_budget_usd=?, max_runtime_min=?, max_turns=?,
-			create_pr=?, pr_title=?, pr_body=?, pr_url=?,
+			create_pr=?, self_review=?, pr_title=?, pr_body=?, pr_url=?,
 			allowed_tools=?, claude_md=?, env_vars=?,
 			instance_id=?, container_id=?, retry_count=?, cost_usd=?, error=?,
 			updated_at=?, started_at=?, completed_at=?
@@ -175,7 +176,7 @@ func (s *SQLiteStore) UpdateTask(ctx context.Context, task *models.Task) error {
 		task.Status, task.RepoURL, task.Branch, task.TargetBranch,
 		task.Prompt, task.Context, task.Model, task.Effort,
 		task.MaxBudgetUSD, task.MaxRuntimeMin, task.MaxTurns,
-		boolToInt(task.CreatePR), task.PRTitle, task.PRBody, task.PRURL,
+		boolToInt(task.CreatePR), boolToInt(task.SelfReview), task.PRTitle, task.PRBody, task.PRURL,
 		task.AllowedToolsJSON(), task.ClaudeMD, task.EnvVarsJSON(),
 		task.InstanceID, task.ContainerID, task.RetryCount, task.CostUSD, task.Error,
 		task.UpdatedAt.Format(time.RFC3339), timePtr(task.StartedAt), timePtr(task.CompletedAt),
@@ -255,7 +256,7 @@ type scanner interface {
 
 func scanTask(row scanner) (*models.Task, error) {
 	var t models.Task
-	var createPR int
+	var createPR, selfReview int
 	var allowedToolsJSON, envVarsJSON string
 	var createdAt, updatedAt string
 	var startedAt, completedAt sql.NullString
@@ -264,7 +265,7 @@ func scanTask(row scanner) (*models.Task, error) {
 		&t.ID, &t.Status, &t.RepoURL, &t.Branch, &t.TargetBranch,
 		&t.Prompt, &t.Context, &t.Model, &t.Effort,
 		&t.MaxBudgetUSD, &t.MaxRuntimeMin, &t.MaxTurns,
-		&createPR, &t.PRTitle, &t.PRBody, &t.PRURL,
+		&createPR, &selfReview, &t.PRTitle, &t.PRBody, &t.PRURL,
 		&allowedToolsJSON, &t.ClaudeMD, &envVarsJSON,
 		&t.InstanceID, &t.ContainerID, &t.RetryCount, &t.CostUSD, &t.Error,
 		&createdAt, &updatedAt, &startedAt, &completedAt,
@@ -277,6 +278,7 @@ func scanTask(row scanner) (*models.Task, error) {
 	}
 
 	t.CreatePR = createPR != 0
+	t.SelfReview = selfReview != 0
 	json.Unmarshal([]byte(allowedToolsJSON), &t.AllowedTools)
 	json.Unmarshal([]byte(envVarsJSON), &t.EnvVars)
 	t.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)

--- a/scripts/create-task.sh
+++ b/scripts/create-task.sh
@@ -31,6 +31,7 @@ Options:
   --pr-body <body>        PR body
   --claude-md <text>      Extra CLAUDE.md content to inject
   --context <text>        Additional context for the prompt
+  --self-review           Enable self-review after PR creation
   --env <KEY=VALUE>       Environment variable (can repeat)
 USAGE
     exit 1
@@ -53,6 +54,7 @@ BUDGET=""
 RUNTIME=""
 TURNS=""
 CREATE_PR=true
+SELF_REVIEW=false
 PR_TITLE=""
 PR_BODY=""
 CLAUDE_MD=""
@@ -69,6 +71,7 @@ while [ $# -gt 0 ]; do
         --runtime)      RUNTIME="$2"; shift 2 ;;
         --turns)        TURNS="$2"; shift 2 ;;
         --pr)           CREATE_PR=true; shift ;;
+        --self-review)  SELF_REVIEW=true; shift ;;
         --pr-title)     PR_TITLE="$2"; shift 2 ;;
         --pr-body)      PR_BODY="$2"; shift 2 ;;
         --claude-md)    CLAUDE_MD="$2"; shift 2 ;;
@@ -90,6 +93,7 @@ JSON=$(jq -n \
     --arg runtime "$RUNTIME" \
     --arg turns "$TURNS" \
     --argjson create_pr "$CREATE_PR" \
+    --argjson self_review "$SELF_REVIEW" \
     --arg pr_title "$PR_TITLE" \
     --arg pr_body "$PR_BODY" \
     --arg claude_md "$CLAUDE_MD" \
@@ -97,7 +101,8 @@ JSON=$(jq -n \
     '{
         repo_url: $repo_url,
         prompt: $prompt,
-        create_pr: $create_pr
+        create_pr: $create_pr,
+        self_review: $self_review
     }
     + if $branch != "" then {branch: $branch} else {} end
     + if $target_branch != "" then {target_branch: $target_branch} else {} end


### PR DESCRIPTION
## Summary
- Add `self_review` bool field to Task model, CreateTaskRequest, SQLite schema, and orchestrator docker env passthrough
- Gate the entrypoint self-review phase on `SELF_REVIEW=true` (previously always ran when a PR existed)
- Add `--self-review` flag to `create-task.sh` script (defaults to `false`)

## Test plan
- [x] All existing tests pass
- [ ] Create task without `--self-review` flag, verify self-review phase is skipped
- [ ] Create task with `--self-review` flag, verify self-review runs after PR creation