### PR TITLE
[backflow] update claude.md (not too long) and rewrite the readme to be

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,72 +1,61 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## What This Is
 
-Backflow is a background agent orchestrator written in Go. It runs Claude Code in ephemeral Docker containers on AWS EC2 spot instances. Tasks are submitted via REST API, and the orchestrator handles provisioning, execution, monitoring, and cleanup.
+Backflow is a Go service that runs Claude Code in ephemeral Docker containers on AWS EC2 spot instances. Tasks come in via REST API; the orchestrator provisions infrastructure, runs agents, and cleans up.
 
 ## Commands
 
 ```bash
-make build          # Build server binary to bin/backflow
+make build          # Build to bin/backflow
 make run            # Build + run (sources .env)
 make test           # go test ./... -v -count=1
 make lint           # go vet ./...
 make deps           # go mod tidy
-make db-status      # Dump SQLite database state
+make db-status      # Dump SQLite state
 make docker-deploy  # Build + push agent image to ECR
 make setup-aws      # Create AWS infrastructure
 ```
 
-Run a single test:
-```bash
-go test ./internal/store/ -run TestCreateTask -v
-```
+Single test: `go test ./internal/store/ -run TestCreateTask -v`
 
 ## Architecture
 
-The server runs two concurrent goroutines: a chi-based REST API on `:8080` and a polling orchestrator (default 5s interval).
+Two goroutines: chi REST API on `:8080` + polling orchestrator (5s default).
 
-**Request flow:** Client → REST API → SQLite store → Orchestrator picks up pending tasks → Dispatches Docker containers on EC2 via SSM → Monitors completion → Fires webhooks.
+**Flow:** Client → API → SQLite → Orchestrator → Docker on EC2 via SSM → Webhooks.
 
 ### Key modules (`internal/`)
 
-- **api/** — chi router, REST handlers, JSON envelope responses
-- **orchestrator/** — The core loop. Contains sub-components:
-  - `orchestrator.go` — Main poll loop, task dispatch, completion detection
-  - `scaler.go` — EC2 instance lifecycle (scale up on demand, terminate after 5min idle)
-  - `docker.go` — Container operations via AWS SSM (run, inspect, stop, logs)
-  - `spot.go` — Spot interruption detection and task re-queuing
-  - `ec2.go` — EC2 launch/terminate/describe operations
-- **store/** — `Store` interface + SQLite implementation (WAL mode)
+- **api/** — chi router, handlers, JSON responses
+- **orchestrator/** — Poll loop, EC2 scaling, Docker via SSM, spot interruption handling
+- **store/** — `Store` interface + SQLite (WAL mode, auto-migrated)
 - **models/** — `Task` and `Instance` structs with status enums
-- **config/** — Environment-variable-based configuration (25+ vars)
-- **notify/** — `Notifier` interface with noop and webhook implementations
+- **config/** — Env-var config (`BACKFLOW_*` prefix)
+- **notify/** — Webhook notifier
 
 ### Agent container (`docker/`)
 
-The Dockerfile builds a Node.js-based image with Claude Code CLI, git, and GitHub CLI. The `entrypoint.sh` script handles the full agent lifecycle: clone → checkout → run Claude Code → commit → push → create PR.
+Node.js image with Claude Code CLI + git + gh. `entrypoint.sh`: clone → checkout → run Claude → commit → push → create PR. Writes `status.json` for the orchestrator.
 
-The orchestrator communicates with containers indirectly by reading a `status.json` file from the stopped container.
+### Statuses
 
-### Task statuses
-
-`pending` → `provisioning` → `running` → `completed` | `failed` | `interrupted` | `cancelled`
-
-### Instance statuses
-
-`pending` → `running` → `draining` → `terminated`
+- **Task:** `pending` → `provisioning` → `running` → `completed` | `failed` | `interrupted` | `cancelled`
+- **Instance:** `pending` → `running` → `draining` → `terminated`
 
 ## Auth modes
 
-- **`api_key`** — Anthropic API key, supports concurrent agents
-- **`max_subscription`** — Claude Max subscription, strictly serial (one agent at a time)
+- **`api_key`** — Anthropic API key, concurrent agents
+- **`max_subscription`** — Claude Max, serial (one agent at a time)
 
 ## Design patterns
 
-- Interface-based abstractions (`Store`, `Notifier`) for testability
-- Polling over event-driven orchestration for simplicity
-- SSM instead of SSH for EC2 communication (no key management)
-- ULID-based task IDs with `bf_` prefix
-- Zerolog for structured logging
+- Interface abstractions (`Store`, `Notifier`) for testability
+- Polling over events for simplicity
+- SSM instead of SSH (no key management)
+- ULID task IDs with `bf_` prefix
+- Zerolog structured logging
+
+## Database
+
+SQLite with WAL mode. Schema auto-migrates on startup via `CREATE TABLE IF NOT EXISTS` in `internal/store/sqlite.go:migrate()`. No separate migration files — add new columns with `ALTER TABLE` idempotently in the same function.

--- a/README.md
+++ b/README.md
@@ -2,38 +2,105 @@
 
 Background agent orchestrator that runs Claude Code in ephemeral Docker containers on AWS EC2 spot instances. POST a task (repo + prompt), get back a branch with commits and optionally a PR.
 
-## Quickstart
+## Prerequisites
+
+- Go 1.24+
+- AWS CLI (configured with credentials)
+- Docker
+- `sqlite3` CLI (for `make db-status`)
+
+## Local Development
+
+### Setup
 
 ```bash
-# Prerequisites: Go 1.24+, AWS CLI (authenticated), Docker, jq, sqlite3
-
 cp .env.example .env
-# Edit .env with your ANTHROPIC_API_KEY, GITHUB_TOKEN, and BACKFLOW_LAUNCH_TEMPLATE_ID
-
-make run
+# Edit .env — at minimum set ANTHROPIC_API_KEY and GITHUB_TOKEN
 ```
 
-Server starts on `localhost:8080`.
+For local-only development without AWS, set `BACKFLOW_MODE=local` in `.env`. This skips EC2 provisioning and runs containers on the local Docker daemon.
 
-### First-time AWS setup
+### Build and Run
+
+```bash
+make build          # Compile to bin/backflow
+make run            # Build + run (auto-sources .env)
+```
+
+Server starts on `http://localhost:8080`. The orchestrator poll loop and HTTP server run as concurrent goroutines.
+
+### Testing
+
+```bash
+make test           # Run all tests (no cache)
+make lint           # go vet
+
+# Run a single test
+go test ./internal/store/ -run TestCreateTask -v
+
+# Run tests for a specific package
+go test ./internal/api/ -v -count=1
+```
+
+Tests create temporary SQLite databases that are cleaned up automatically. No external services needed.
+
+### Build the Agent Image Locally
+
+```bash
+make docker-build-local    # Single-arch build, no push
+```
+
+## Database
+
+Backflow uses SQLite in WAL mode. The database file location is configured via `BACKFLOW_DB_PATH` (default: `backflow.db` in the working directory).
+
+### Schema
+
+Two tables: `tasks` and `instances`. See `internal/store/sqlite.go` for the full schema.
+
+### Migrations
+
+There are no separate migration files. Schema is managed in `internal/store/sqlite.go` in the `migrate()` method. All DDL uses `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`, so it's safe to run on every startup.
+
+**To add a new column:**
+
+1. Add an `ALTER TABLE ... ADD COLUMN` statement to `migrate()` in `internal/store/sqlite.go`, wrapped in an idempotent check (SQLite will error if the column already exists, so ignore the error or check `pragma table_info` first).
+2. Update the `INSERT`, `UPDATE`, and `SELECT` statements in the same file.
+3. Update the model struct in `internal/models/`.
+
+**To inspect the database:**
+
+```bash
+make db-status                              # Dump all tasks and instances
+sqlite3 backflow.db ".schema"               # Show schema
+sqlite3 backflow.db "SELECT id, status, created_at FROM tasks ORDER BY created_at DESC LIMIT 10;"
+```
+
+**To reset the database:** delete the `backflow.db` file. It will be recreated on next startup.
+
+## AWS Setup (EC2 Mode)
+
+### One-Time Infrastructure
 
 ```bash
 make setup-aws
 ```
 
-Creates ECR repo, IAM role, security group, and launch template. Grab the `BACKFLOW_LAUNCH_TEMPLATE_ID` from the output and put it in `.env`.
+This creates: ECR repo, IAM role, security group, and launch template. Copy the `BACKFLOW_LAUNCH_TEMPLATE_ID` from the output into `.env`.
 
-Then build and push the agent image:
+### Deploy Agent Image
 
 ```bash
 make docker-deploy
 # If docker needs sudo: make docker-deploy DOCKER="sudo docker"
 ```
 
-## Submitting tasks
+Builds a multi-arch image (amd64 + arm64) and pushes to ECR.
+
+## Submitting Tasks
 
 ```bash
-# Simple
+# Simple task
 ./scripts/create-task.sh https://github.com/org/repo "Fix the login bug"
 
 # With PR creation
@@ -49,7 +116,7 @@ make docker-deploy
   --env "GOPRIVATE=github.com/org/*"
 ```
 
-Or hit the API directly:
+Or call the API directly:
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/tasks \
@@ -57,90 +124,52 @@ curl -X POST http://localhost:8080/api/v1/tasks \
   -d '{"repo_url": "https://github.com/org/repo", "prompt": "Fix the bug", "create_pr": true}'
 ```
 
-## Monitoring
+## Monitoring and Operations
 
 ```bash
-# Dump all tasks and instances from the database
+# Database state
 make db-status
 
-# Get task details
+# Task details
 curl http://localhost:8080/api/v1/tasks/{id}
 
-# Stream container logs
+# Container logs
 curl http://localhost:8080/api/v1/tasks/{id}/logs?tail=100
 
-# Shell into an agent VM
+# Health check
+curl http://localhost:8080/api/v1/health
+
+# Shell into an agent EC2 instance
 aws ssm start-session --target i-0abc...
 ```
 
-## Development
+### Task Lifecycle
 
-```bash
-make build      # Compile to bin/backflow
-make test       # go test ./... -v -count=1
-make lint       # go vet ./...
-make deps       # go mod tidy
-make db-status  # Dump SQLite state
-```
+`pending` → `provisioning` → `running` → `completed` | `failed` | `interrupted` | `cancelled`
 
-Run a single test:
+### Instance Lifecycle
 
-```bash
-go test ./internal/store/ -run TestCreateTask -v
-```
+`pending` → `running` → idle 5 min → `terminated`. Spot interruptions automatically re-queue affected tasks.
 
-Build the agent image locally (no push):
-
-```bash
-make docker-build-local
-```
-
-## API
+## API Reference
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/api/v1/tasks` | Create a task |
 | `GET` | `/api/v1/tasks` | List tasks (`?status=`, `?limit=`, `?offset=`) |
-| `GET` | `/api/v1/tasks/{id}` | Get a task |
+| `GET` | `/api/v1/tasks/{id}` | Get task details |
 | `DELETE` | `/api/v1/tasks/{id}` | Cancel a task |
 | `GET` | `/api/v1/tasks/{id}/logs` | Container logs (`?tail=100`) |
 | `GET` | `/api/v1/health` | Health check |
 
-## Architecture
+## Auth Modes
 
-```
-Client ──▶ REST API (:8080, chi router)
-               │
-               ▼
-          SQLite (WAL)
-               │
-               ▼
-         Orchestrator (5s poll loop)
-          ├── Scaler ── launch/terminate EC2 spot instances
-          ├── Docker ── run containers via SSM
-          └── Spot ──── detect interruptions, re-queue tasks
-               │
-               ▼ SSM
-         EC2 Spot Instance
-          └── Docker container (backflow-agent)
-               ├── Clone repo
-               ├── Run Claude Code
-               ├── Commit + push
-               └── Create PR
-```
-
-**Task lifecycle:** `pending` → `provisioning` → `running` → `completed` | `failed` | `interrupted` | `cancelled`
-
-**Instance lifecycle:** `pending` → `running` → idle 5 min → `terminated`. Spot interruptions re-queue affected tasks.
-
-## Auth modes
-
-- **`api_key`** (default) — Anthropic API key. Multiple concurrent agents. Pay per token.
-- **`max_subscription`** — Claude Max subscription credentials. One agent at a time. Flat rate.
+- **`api_key`** (default) — Uses Anthropic API key. Supports multiple concurrent agents. Pay per token.
+- **`max_subscription`** — Uses Claude Max subscription credentials. One agent at a time. Flat rate.
 
 ## Webhooks
 
-Set `BACKFLOW_WEBHOOK_URL` in `.env` to receive POST notifications:
+Set `BACKFLOW_WEBHOOK_URL` in `.env`:
 
 ```json
 {
@@ -160,24 +189,27 @@ Filter with `BACKFLOW_WEBHOOK_EVENTS=task.completed,task.failed`.
 
 ## Configuration
 
+All config is via environment variables (or `.env` file).
+
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `BACKFLOW_MODE` | `ec2` | `ec2` or `local` |
 | `BACKFLOW_AUTH_MODE` | `api_key` | `api_key` or `max_subscription` |
 | `ANTHROPIC_API_KEY` | | Required for `api_key` mode |
 | `CLAUDE_CREDENTIALS_PATH` | | Path to `~/.claude/` for `max_subscription` mode |
-| `GITHUB_TOKEN` | | Cloning private repos and creating PRs |
+| `GITHUB_TOKEN` | | For cloning private repos and creating PRs |
 | `BACKFLOW_LISTEN_ADDR` | `:8080` | Server listen address |
 | `BACKFLOW_DB_PATH` | `backflow.db` | SQLite database path |
 | `AWS_REGION` | `us-east-1` | AWS region |
 | `BACKFLOW_INSTANCE_TYPE` | `t4g.medium` | EC2 instance type |
-| `BACKFLOW_LAUNCH_TEMPLATE_ID` | | Launch template from `make setup-aws` |
+| `BACKFLOW_LAUNCH_TEMPLATE_ID` | | From `make setup-aws` |
 | `BACKFLOW_MAX_INSTANCES` | `5` | Max EC2 instances |
-| `BACKFLOW_CONTAINERS_PER_INSTANCE` | `4` | Max containers per instance |
+| `BACKFLOW_CONTAINERS_PER_INSTANCE` | `4` | Containers per instance |
 | `BACKFLOW_DEFAULT_MODEL` | `claude-sonnet-4-6` | Default Claude model |
-| `BACKFLOW_DEFAULT_MAX_BUDGET` | `10` | Default max budget (USD) |
-| `BACKFLOW_DEFAULT_MAX_RUNTIME_MIN` | `30` | Default max runtime (minutes) |
-| `BACKFLOW_DEFAULT_MAX_TURNS` | `200` | Default max conversation turns |
+| `BACKFLOW_DEFAULT_MAX_BUDGET` | `10` | Default budget (USD) |
+| `BACKFLOW_DEFAULT_MAX_RUNTIME_MIN` | `30` | Default max runtime (min) |
+| `BACKFLOW_DEFAULT_MAX_TURNS` | `200` | Default max turns |
 | `BACKFLOW_WEBHOOK_URL` | | Webhook endpoint |
 | `BACKFLOW_WEBHOOK_EVENTS` | all | Comma-separated event filter |
-| `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator poll interval |
-| `DOCKER` | `docker` | Docker command (`sudo docker` if needed) |
+| `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator poll interval (sec) |
+| `DOCKER` | `docker` | Docker command (e.g. `sudo docker`) |


### PR DESCRIPTION
## Summary
- **README.md**: Reorganized into dev-friendly sections — prerequisites, local dev setup (`BACKFLOW_MODE=local`), testing, database management, AWS setup, task submission, monitoring/ops, API reference, and full config table
- **README.md**: Added dedicated Database section with migration workflow (how to add columns, inspect DB, reset), since there are no separate migration files
- **CLAUDE.md**: Trimmed to essentials — removed verbose sub-component listings and redundant descriptions. Added a Database section documenting the auto-migration approach in `migrate()`

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm CLAUDE.md still provides sufficient context for Claude Code sessions
- [ ] Check all `make` targets referenced in docs still work (`make build`, `make test`, `make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)