### PR TITLE
[backflow] Let claude generate the PR title

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -84,12 +84,18 @@ After completing the coding task, you MUST do the following git operations:
 
 # Append PR creation instructions if requested
 if [ "$CREATE_PR" = "true" ]; then
-    PR_TITLE_FINAL="${PR_TITLE:-[backflow] ${PROMPT:0:60}}"
     GIT_INSTRUCTIONS="${GIT_INSTRUCTIONS}
 3. Create a pull request using the gh CLI:
    - Base branch: ${TARGET_BRANCH}
-   - Head branch: ${BRANCH}
-   - Title: ${PR_TITLE_FINAL}"
+   - Head branch: ${BRANCH}"
+
+    if [ -n "$PR_TITLE" ]; then
+        GIT_INSTRUCTIONS="${GIT_INSTRUCTIONS}
+   - Title: ${PR_TITLE}"
+    else
+        GIT_INSTRUCTIONS="${GIT_INSTRUCTIONS}
+   - Title: [backflow] <generate a concise, descriptive title based on the changes you made>"
+    fi
 
     if [ -n "$PR_BODY" ]; then
         GIT_INSTRUCTIONS="${GIT_INSTRUCTIONS}


### PR DESCRIPTION
## Summary

- When no `PR_TITLE` is provided by the user, the agent now generates its own descriptive PR title based on the actual changes it made, rather than using a truncated version of the prompt (`[backflow] <first 60 chars>`)
- User-provided `PR_TITLE` values are still used exactly as-is (no behavior change)
- The generated title is prefixed with `[backflow]` for consistency

## Test plan

- [ ] Create a task with `create_pr=true` and a `pr_title` — verify the provided title is used unchanged
- [ ] Create a task with `create_pr=true` and no `pr_title` — verify the agent generates a meaningful, descriptive title prefixed with `[backflow]`
- [ ] Create a task with `create_pr=false` — verify no PR-related instructions are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)