### PR TITLE
[backflow] Commit agent output and comment prompt on PR

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -239,6 +239,28 @@ if [ "$CREATE_PR" = "true" ] && [ "$COMPLETE" = "true" ]; then
     fi
 fi
 
+# --- Commit agent output ---
+if [ "$COMPLETE" = "true" ]; then
+    echo "==> Committing agent output..."
+    OUTPUT_FILENAME=".backflow/agent_output_$(date +%s%N).log"
+    mkdir -p "$(dirname "$OUTPUT_FILENAME")"
+    cp "$CLAUDE_LOG" "$OUTPUT_FILENAME"
+    git add "$OUTPUT_FILENAME"
+    git commit -m "backflow: save agent output log" --no-verify || true
+    git push origin "$BRANCH" || true
+fi
+
+# --- Comment prompt on PR ---
+if [ -n "$PR_URL" ]; then
+    echo "==> Commenting prompt on PR..."
+    COMMENT_BODY="## Backflow Agent Prompt
+
+\`\`\`
+${PROMPT}
+\`\`\`"
+    gh pr comment "$PR_URL" --body "$COMMENT_BODY" 2>/dev/null || true
+fi
+
 # --- Self-review phase ---
 if [ "$SELF_REVIEW" = "true" ] && [ -n "$PR_URL" ]; then
     echo "==> Starting self-review phase..."


### PR DESCRIPTION
## Summary

- After agent execution completes (but before the self-review phase), the agent output log (`claude_output.log`) is now saved to `.backflow/agent_output_<timestamp>.log` with a unique nanosecond-precision filename, committed, and pushed to the working branch.
- If a PR exists, the original prompt is posted as a comment on the PR for traceability.
- Both operations are best-effort (failures are tolerated with `|| true`) to avoid breaking the pipeline.

## Test plan

- [ ] Run a task with `create_pr=true` and verify `.backflow/agent_output_*.log` appears in the branch history
- [ ] Verify the PR has a comment containing the original prompt
- [ ] Run a task with `self_review=true` and confirm the output commit and prompt comment happen before the review phase
- [ ] Run a task that fails (`COMPLETE=false`) and verify no output log is committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)