### PR TITLE
Replace /review-pr with explicit prompt and stream-json

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -240,28 +240,50 @@ if [ "$SELF_REVIEW" = "true" ] && [ -n "$PR_URL" ]; then
     # Cap review budget at 20% of coding budget (minimum $2)
     REVIEW_BUDGET=$(echo "$MAX_BUDGET_USD" | awk '{b = $1 * 0.2; print (b < 2) ? 2 : b}')
 
-    # Use Claude Code's built-in /review-pr command
+    REVIEW_PROMPT="You are reviewing a pull request that you (a different instance) just created.
+
+PR URL: ${PR_URL}
+
+Review the PR by:
+1. Read the full diff with: gh pr diff ${PR_URL}
+2. Look at the PR description with: gh pr view ${PR_URL}
+
+Focus on:
+- Bugs and logic errors
+- Security issues
+- Missing error handling that could cause failures
+- Correctness of the implementation vs the PR description
+
+Do NOT comment on:
+- Code style or formatting
+- Minor naming preferences
+- Things that are working correctly
+
+Respond with your review findings. If everything looks good, say so. If there are real issues, explain what needs fixing."
+
     REVIEW_ARGS=(
-        -p "/review-pr"
+        -p "$REVIEW_PROMPT"
         --dangerously-skip-permissions
         --model "$MODEL"
-        --output-format json
+        --max-turns 10
+        --output-format stream-json
         --verbose
     )
     if [ "$AUTH_MODE" = "api_key" ]; then
         REVIEW_ARGS+=(--max-budget-usd "$REVIEW_BUDGET")
     fi
 
+    REVIEW_LOG="${WORKSPACE}/review_output.log"
     set +e
-    REVIEW_OUTPUT=$(claude "${REVIEW_ARGS[@]}" 2>&1)
-    REVIEW_EXIT=$?
+    claude "${REVIEW_ARGS[@]}" 2>&1 | tee "$REVIEW_LOG"
+    REVIEW_EXIT=${PIPESTATUS[0]}
     set -e
 
     if [ $REVIEW_EXIT -eq 0 ]; then
         echo "==> Self-review completed successfully"
 
-        # Extract review text from JSON output and post as PR comment
-        REVIEW_TEXT=$(echo "$REVIEW_OUTPUT" | jq -r '.result // empty' 2>/dev/null)
+        # Extract review text from stream-json result line
+        REVIEW_TEXT=$(grep '"type":"result"' "$REVIEW_LOG" | tail -1 | jq -r '.result // empty' 2>/dev/null)
         if [ -n "$REVIEW_TEXT" ]; then
             echo "==> Posting review feedback as PR comment..."
             COMMENT_BODY="## Self-Review (automated)


### PR DESCRIPTION
## Summary
- Replace the built-in `/review-pr` slash command with an explicit review prompt for more control over review behavior
- Switch from `json` to `stream-json` output format with `tee` for real-time logging during review
- Bump `--max-turns` to 10 so the reviewer has room to inspect the diff thoroughly
- Parse review result from the stream-json log file instead of captured stdout

## Test plan
- [ ] Run a task with `SELF_REVIEW=true` and verify review output streams in real-time
- [ ] Confirm review feedback is extracted from the log and posted as a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)