### PR TITLE
[backflow] Inline task columns into SQLite bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Two goroutines: chi REST API on `:8080` + polling orchestrator (5s default). Two
 
 - **api/** — chi router, handlers, JSON responses, `LogFetcher` interface
 - **orchestrator/** — Poll loop (`orchestrator.go`), EC2 scaling (`ec2.go`, `scaler.go`), Docker via SSM (`docker.go`), spot interruption handling (`spot.go`), local mode (`local.go`)
-- **store/** — `Store` interface + SQLite (WAL mode, auto-migrated)
+- **store/** — `Store` interface + SQLite (WAL mode, schema bootstrapped at startup)
 - **models/** — `Task` and `Instance` structs with status enums
 - **config/** — Env-var config (`BACKFLOW_*` prefix), two modes (`ec2`/`local`)
 - **notify/** — `Notifier` interface, `WebhookNotifier` (HTTP POST, 3 retries, event filtering), `NoopNotifier`
@@ -76,7 +76,7 @@ Node.js 20 image with Claude Code CLI + git + gh. `entrypoint.sh`: clone → che
 
 ## Database
 
-SQLite with WAL mode. Schema auto-migrates on startup via `CREATE TABLE IF NOT EXISTS` in `internal/store/sqlite.go:migrate()`. No separate migration files — add new columns with `ALTER TABLE` idempotently in the same function.
+SQLite with WAL mode. Schema is bootstrapped on startup via `CREATE TABLE IF NOT EXISTS` in `internal/store/sqlite.go:migrate()`. No separate migration files. Add new columns directly to the table definition and keep the CRUD statements in sync.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Two tables: `tasks` and `instances`. See `internal/store/sqlite.go` for the full
 
 ### Migrations
 
-There are no separate migration files. Schema is managed in `internal/store/sqlite.go` in the `migrate()` method. All DDL uses `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`, so it's safe to run on every startup.
+There are no separate migration files. Schema is managed in `internal/store/sqlite.go` in the `migrate()` method. All columns are declared directly in the `CREATE TABLE IF NOT EXISTS` statements, and indexes use `CREATE INDEX IF NOT EXISTS`, so bootstrap is safe to run on every startup.
 
 **To add a new column:**
 
-1. Add an `ALTER TABLE ... ADD COLUMN` statement to `migrate()` in `internal/store/sqlite.go`, wrapped in an idempotent check (SQLite will error if the column already exists, so ignore the error or check `pragma table_info` first).
+1. Add the column definition to the relevant `CREATE TABLE IF NOT EXISTS` statement in `migrate()` in `internal/store/sqlite.go`.
 2. Update the `INSERT`, `UPDATE`, and `SELECT` statements in the same file.
 3. Update the model struct in `internal/models/`.
 

--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -79,7 +79,7 @@ Persistence layer.
 | File | Description |
 |------|-------------|
 | `store.go` | `Store` interface defining CRUD operations for tasks (`Create`, `Get`, `List`, `Update`, `Delete`) and instances (`Create`, `Get`, `List`, `Update`), plus `Close()`. `TaskFilter` struct for list queries with status filter, limit, and offset. |
-| `sqlite.go` | SQLite implementation of `Store`. Opens the database in WAL mode with busy timeout and foreign keys. `migrate()` creates the `tasks` and `instances` tables with indexes on status and created_at. Implements all CRUD operations with full field scanning, JSON serialization for `allowed_tools` and `env_vars`, and RFC3339 timestamp handling. |
+| `sqlite.go` | SQLite implementation of `Store`. Opens the database in WAL mode with busy timeout and foreign keys. `migrate()` bootstraps the full `tasks` and `instances` schemas, including indexes on status and created_at. Implements all CRUD operations with full field scanning, JSON serialization for `allowed_tools` and `env_vars`, and RFC3339 timestamp handling. |
 | `sqlite_test.go` | Tests for SQLite store — full task CRUD cycle (create, get, update, list with filter, delete), not-found handling, and instance CRUD (create, get, update, list by status). Uses temp DB files with cleanup. |
 
 ## `docker/`

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,6 @@
 # Database Schema
 
-Backflow uses SQLite in WAL mode with foreign keys enabled. The schema is auto-migrated on startup via `internal/store/sqlite.go:migrate()` using `CREATE TABLE IF NOT EXISTS` statements.
+Backflow uses SQLite in WAL mode with foreign keys enabled. The schema is initialized on startup via `internal/store/sqlite.go:migrate()` using `CREATE TABLE IF NOT EXISTS` statements.
 
 Connection string: `<path>?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on`
 
@@ -14,9 +14,11 @@ Stores Claude Code agent tasks submitted via the REST API.
 |--------|------|---------|-------------|
 | `id` | `TEXT` | — | **Primary key.** ULID with `bf_` prefix (e.g. `bf_01KKQW82994E87Z99QVEMBN8V0`). |
 | `status` | `TEXT` | `'pending'` | Task lifecycle state. One of: `pending`, `provisioning`, `running`, `completed`, `failed`, `interrupted`, `cancelled`, `recovering`. |
+| `task_mode` | `TEXT` | `'code'` | Task execution mode. `code` runs an implementation task; `review` reviews an existing PR. |
 | `repo_url` | `TEXT` | — | Git repository URL to clone (required). |
 | `branch` | `TEXT` | `''` | Branch to check out before running the agent. |
 | `target_branch` | `TEXT` | `''` | Base branch for PR creation (e.g. `main`). |
+| `review_pr_number` | `INTEGER` | `0` | Pull request number to review when `task_mode='review'`. |
 | `prompt` | `TEXT` | — | The instruction given to Claude Code (required). |
 | `context` | `TEXT` | `''` | Additional context appended to the prompt. |
 | `model` | `TEXT` | `''` | Claude model override (e.g. `claude-sonnet-4-20250514`). |
@@ -95,4 +97,4 @@ pending → running → draining → terminated
 - All timestamps are stored as RFC 3339 strings, not SQLite datetime types.
 - Booleans (`create_pr`, `self_review`) are stored as integers (0/1).
 - JSON fields (`allowed_tools`, `env_vars`) are stored as serialized TEXT.
-- Schema changes are applied idempotently in `migrate()` — new columns use `ALTER TABLE ... ADD COLUMN` with `IF NOT EXISTS` semantics.
+- New databases are bootstrapped entirely from the `CREATE TABLE IF NOT EXISTS` definitions in `migrate()`.

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -37,35 +37,37 @@ func (s *SQLiteStore) Close() error {
 func (s *SQLiteStore) migrate() error {
 	schema := `
 	CREATE TABLE IF NOT EXISTS tasks (
-		id              TEXT PRIMARY KEY,
-		status          TEXT NOT NULL DEFAULT 'pending',
-		repo_url        TEXT NOT NULL,
-		branch          TEXT NOT NULL DEFAULT '',
-		target_branch   TEXT NOT NULL DEFAULT '',
-		prompt          TEXT NOT NULL,
-		context         TEXT NOT NULL DEFAULT '',
-		model           TEXT NOT NULL DEFAULT '',
-		effort          TEXT NOT NULL DEFAULT '',
-		max_budget_usd  REAL NOT NULL DEFAULT 0,
-		max_runtime_min INTEGER NOT NULL DEFAULT 0,
-		max_turns       INTEGER NOT NULL DEFAULT 0,
-		create_pr       INTEGER NOT NULL DEFAULT 0,
-		self_review     INTEGER NOT NULL DEFAULT 0,
-		pr_title        TEXT NOT NULL DEFAULT '',
-		pr_body         TEXT NOT NULL DEFAULT '',
-		pr_url          TEXT NOT NULL DEFAULT '',
-		allowed_tools   TEXT NOT NULL DEFAULT '[]',
-		claude_md       TEXT NOT NULL DEFAULT '',
-		env_vars        TEXT NOT NULL DEFAULT '{}',
-		instance_id     TEXT NOT NULL DEFAULT '',
-		container_id    TEXT NOT NULL DEFAULT '',
-		retry_count     INTEGER NOT NULL DEFAULT 0,
-		cost_usd        REAL NOT NULL DEFAULT 0,
-		error           TEXT NOT NULL DEFAULT '',
-		created_at      TEXT NOT NULL,
-		updated_at      TEXT NOT NULL,
-		started_at      TEXT,
-		completed_at    TEXT
+		id               TEXT PRIMARY KEY,
+		status           TEXT NOT NULL DEFAULT 'pending',
+		task_mode        TEXT NOT NULL DEFAULT 'code',
+		repo_url         TEXT NOT NULL,
+		branch           TEXT NOT NULL DEFAULT '',
+		target_branch    TEXT NOT NULL DEFAULT '',
+		review_pr_number INTEGER NOT NULL DEFAULT 0,
+		prompt           TEXT NOT NULL,
+		context          TEXT NOT NULL DEFAULT '',
+		model            TEXT NOT NULL DEFAULT '',
+		effort           TEXT NOT NULL DEFAULT '',
+		max_budget_usd   REAL NOT NULL DEFAULT 0,
+		max_runtime_min  INTEGER NOT NULL DEFAULT 0,
+		max_turns        INTEGER NOT NULL DEFAULT 0,
+		create_pr        INTEGER NOT NULL DEFAULT 0,
+		self_review      INTEGER NOT NULL DEFAULT 0,
+		pr_title         TEXT NOT NULL DEFAULT '',
+		pr_body          TEXT NOT NULL DEFAULT '',
+		pr_url           TEXT NOT NULL DEFAULT '',
+		allowed_tools    TEXT NOT NULL DEFAULT '[]',
+		claude_md        TEXT NOT NULL DEFAULT '',
+		env_vars         TEXT NOT NULL DEFAULT '{}',
+		instance_id      TEXT NOT NULL DEFAULT '',
+		container_id     TEXT NOT NULL DEFAULT '',
+		retry_count      INTEGER NOT NULL DEFAULT 0,
+		cost_usd         REAL NOT NULL DEFAULT 0,
+		error            TEXT NOT NULL DEFAULT '',
+		created_at       TEXT NOT NULL,
+		updated_at       TEXT NOT NULL,
+		started_at       TEXT,
+		completed_at     TEXT
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
@@ -87,15 +89,6 @@ func (s *SQLiteStore) migrate() error {
 	`
 	if _, err := s.db.Exec(schema); err != nil {
 		return err
-	}
-
-	// Idempotent migrations for new columns
-	migrations := []string{
-		"ALTER TABLE tasks ADD COLUMN task_mode TEXT NOT NULL DEFAULT 'code'",
-		"ALTER TABLE tasks ADD COLUMN review_pr_number INTEGER NOT NULL DEFAULT 0",
-	}
-	for _, m := range migrations {
-		s.db.Exec(m) // ignore "duplicate column" errors
 	}
 	return nil
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"testing"
 	"time"
@@ -128,6 +129,41 @@ func TestGetTaskNotFound(t *testing.T) {
 	}
 	if got != nil {
 		t.Error("expected nil for nonexistent task")
+	}
+}
+
+func TestBootstrapSchemaIncludesTaskColumns(t *testing.T) {
+	s := testStore(t)
+
+	rows, err := s.db.Query("PRAGMA table_info(tasks)")
+	if err != nil {
+		t.Fatalf("PRAGMA table_info(tasks): %v", err)
+	}
+	defer rows.Close()
+
+	columns := map[string]bool{}
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			dataType   string
+			notNull    int
+			defaultV   sql.NullString
+			primaryKey int
+		)
+		if err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultV, &primaryKey); err != nil {
+			t.Fatalf("scan table_info: %v", err)
+		}
+		columns[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate table_info: %v", err)
+	}
+
+	for _, name := range []string{"task_mode", "review_pr_number"} {
+		if !columns[name] {
+			t.Fatalf("expected %q column in tasks bootstrap schema", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- move `task_mode` and `review_pr_number` into the initial `tasks` table definition in `internal/store/sqlite.go`
- remove the follow-up SQLite `ALTER TABLE` migration path so schema bootstrap happens entirely from `CREATE TABLE IF NOT EXISTS`
- add a store test that asserts the bootstrap schema contains those columns and update repo docs to describe the new pattern

## Why
- the schema should now be defined in one place instead of relying on post-creation add-column migrations
- this matches the requested model of creating all columns directly in the table definition

## Verification
- unable to run `go test ./internal/store/...` in this environment because the `go` toolchain is not installed
