### PR TITLE
[backflow] Inline SQLite task schema columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Node.js 20 image with Claude Code CLI + git + gh. `entrypoint.sh`: clone → che
 
 ## Database
 
-SQLite with WAL mode. Schema auto-migrates on startup via `CREATE TABLE IF NOT EXISTS` in `internal/store/sqlite.go:migrate()`. No separate migration files — add new columns with `ALTER TABLE` idempotently in the same function.
+SQLite with WAL mode. Schema is initialized on startup via `CREATE TABLE IF NOT EXISTS` in `internal/store/sqlite.go:ensureSchema()`. No separate migration files — define new columns directly in the table creation SQL and update the related CRUD code in the same file.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Two tables: `tasks` and `instances`. See `internal/store/sqlite.go` for the full
 
 ### Migrations
 
-There are no separate migration files. Schema is managed in `internal/store/sqlite.go` in the `migrate()` method. All DDL uses `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`, so it's safe to run on every startup.
+There are no separate migration files. Schema is managed in `internal/store/sqlite.go` in the `ensureSchema()` method. All columns are declared directly in the `CREATE TABLE IF NOT EXISTS` statements, and indexes use `CREATE INDEX IF NOT EXISTS`, so startup schema creation is idempotent for a fresh database.
 
 **To add a new column:**
 
-1. Add an `ALTER TABLE ... ADD COLUMN` statement to `migrate()` in `internal/store/sqlite.go`, wrapped in an idempotent check (SQLite will error if the column already exists, so ignore the error or check `pragma table_info` first).
+1. Add the column definition to the appropriate `CREATE TABLE IF NOT EXISTS` statement in `ensureSchema()` in `internal/store/sqlite.go`.
 2. Update the `INSERT`, `UPDATE`, and `SELECT` statements in the same file.
 3. Update the model struct in `internal/models/`.
 

--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -79,7 +79,7 @@ Persistence layer.
 | File | Description |
 |------|-------------|
 | `store.go` | `Store` interface defining CRUD operations for tasks (`Create`, `Get`, `List`, `Update`, `Delete`) and instances (`Create`, `Get`, `List`, `Update`), plus `Close()`. `TaskFilter` struct for list queries with status filter, limit, and offset. |
-| `sqlite.go` | SQLite implementation of `Store`. Opens the database in WAL mode with busy timeout and foreign keys. `migrate()` creates the `tasks` and `instances` tables with indexes on status and created_at. Implements all CRUD operations with full field scanning, JSON serialization for `allowed_tools` and `env_vars`, and RFC3339 timestamp handling. |
+| `sqlite.go` | SQLite implementation of `Store`. Opens the database in WAL mode with busy timeout and foreign keys. `ensureSchema()` creates the `tasks` and `instances` tables with their full column sets plus indexes on status and created_at. Implements all CRUD operations with full field scanning, JSON serialization for `allowed_tools` and `env_vars`, and RFC3339 timestamp handling. |
 | `sqlite_test.go` | Tests for SQLite store — full task CRUD cycle (create, get, update, list with filter, delete), not-found handling, and instance CRUD (create, get, update, list by status). Uses temp DB files with cleanup. |
 
 ## `docker/`

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,6 @@
 # Database Schema
 
-Backflow uses SQLite in WAL mode with foreign keys enabled. The schema is auto-migrated on startup via `internal/store/sqlite.go:migrate()` using `CREATE TABLE IF NOT EXISTS` statements.
+Backflow uses SQLite in WAL mode with foreign keys enabled. The schema is initialized on startup via `internal/store/sqlite.go:ensureSchema()` using `CREATE TABLE IF NOT EXISTS` statements.
 
 Connection string: `<path>?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on`
 
@@ -14,9 +14,11 @@ Stores Claude Code agent tasks submitted via the REST API.
 |--------|------|---------|-------------|
 | `id` | `TEXT` | — | **Primary key.** ULID with `bf_` prefix (e.g. `bf_01KKQW82994E87Z99QVEMBN8V0`). |
 | `status` | `TEXT` | `'pending'` | Task lifecycle state. One of: `pending`, `provisioning`, `running`, `completed`, `failed`, `interrupted`, `cancelled`, `recovering`. |
+| `task_mode` | `TEXT` | `'code'` | Task execution mode. One of: `code` or `review`. |
 | `repo_url` | `TEXT` | — | Git repository URL to clone (required). |
 | `branch` | `TEXT` | `''` | Branch to check out before running the agent. |
 | `target_branch` | `TEXT` | `''` | Base branch for PR creation (e.g. `main`). |
+| `review_pr_number` | `INTEGER` | `0` | Pull request number to review when `task_mode = 'review'`. |
 | `prompt` | `TEXT` | — | The instruction given to Claude Code (required). |
 | `context` | `TEXT` | `''` | Additional context appended to the prompt. |
 | `model` | `TEXT` | `''` | Claude model override (e.g. `claude-sonnet-4-20250514`). |
@@ -95,4 +97,4 @@ pending → running → draining → terminated
 - All timestamps are stored as RFC 3339 strings, not SQLite datetime types.
 - Booleans (`create_pr`, `self_review`) are stored as integers (0/1).
 - JSON fields (`allowed_tools`, `env_vars`) are stored as serialized TEXT.
-- Schema changes are applied idempotently in `migrate()` — new columns use `ALTER TABLE ... ADD COLUMN` with `IF NOT EXISTS` semantics.
+- The schema bootstrap is idempotent for fresh databases because tables and indexes use `IF NOT EXISTS`.

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -23,9 +23,9 @@ func NewSQLite(dbPath string) (*SQLiteStore, error) {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
 	s := &SQLiteStore{db: db}
-	if err := s.migrate(); err != nil {
+	if err := s.ensureSchema(); err != nil {
 		db.Close()
-		return nil, fmt.Errorf("migrate: %w", err)
+		return nil, fmt.Errorf("ensure schema: %w", err)
 	}
 	return s, nil
 }
@@ -34,14 +34,16 @@ func (s *SQLiteStore) Close() error {
 	return s.db.Close()
 }
 
-func (s *SQLiteStore) migrate() error {
+func (s *SQLiteStore) ensureSchema() error {
 	schema := `
 	CREATE TABLE IF NOT EXISTS tasks (
 		id              TEXT PRIMARY KEY,
 		status          TEXT NOT NULL DEFAULT 'pending',
+		task_mode       TEXT NOT NULL DEFAULT 'code',
 		repo_url        TEXT NOT NULL,
 		branch          TEXT NOT NULL DEFAULT '',
 		target_branch   TEXT NOT NULL DEFAULT '',
+		review_pr_number INTEGER NOT NULL DEFAULT 0,
 		prompt          TEXT NOT NULL,
 		context         TEXT NOT NULL DEFAULT '',
 		model           TEXT NOT NULL DEFAULT '',
@@ -87,15 +89,6 @@ func (s *SQLiteStore) migrate() error {
 	`
 	if _, err := s.db.Exec(schema); err != nil {
 		return err
-	}
-
-	// Idempotent migrations for new columns
-	migrations := []string{
-		"ALTER TABLE tasks ADD COLUMN task_mode TEXT NOT NULL DEFAULT 'code'",
-		"ALTER TABLE tasks ADD COLUMN review_pr_number INTEGER NOT NULL DEFAULT 0",
-	}
-	for _, m := range migrations {
-		s.db.Exec(m) // ignore "duplicate column" errors
 	}
 	return nil
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -222,4 +224,90 @@ func TestReviewTaskCRUD(t *testing.T) {
 	if got.Prompt != "Focus on security" {
 		t.Errorf("Prompt = %q, want %q", got.Prompt, "Focus on security")
 	}
+}
+
+func TestSchemaIncludesAllTaskColumns(t *testing.T) {
+	s := testStore(t)
+
+	rows, err := s.db.Query(`PRAGMA table_info(tasks)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info(tasks): %v", err)
+	}
+	defer rows.Close()
+
+	var (
+		cid        int
+		name       string
+		columnType string
+		notNull    int
+		defaultVal any
+		pk         int
+	)
+	var columns []string
+	for rows.Next() {
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultVal, &pk); err != nil {
+			t.Fatalf("scan PRAGMA row: %v", err)
+		}
+		columns = append(columns, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate PRAGMA rows: %v", err)
+	}
+
+	expected := []string{
+		"id",
+		"status",
+		"task_mode",
+		"repo_url",
+		"branch",
+		"target_branch",
+		"review_pr_number",
+		"prompt",
+		"context",
+		"model",
+		"effort",
+		"max_budget_usd",
+		"max_runtime_min",
+		"max_turns",
+		"create_pr",
+		"self_review",
+		"pr_title",
+		"pr_body",
+		"pr_url",
+		"allowed_tools",
+		"claude_md",
+		"env_vars",
+		"instance_id",
+		"container_id",
+		"retry_count",
+		"cost_usd",
+		"error",
+		"created_at",
+		"updated_at",
+		"started_at",
+		"completed_at",
+	}
+
+	if len(columns) != len(expected) {
+		t.Fatalf("tasks column count = %d, want %d (%v)", len(columns), len(expected), columns)
+	}
+	for i := range expected {
+		if columns[i] != expected[i] {
+			t.Fatalf("tasks column %d = %q, want %q; full schema: %v", i, columns[i], expected[i], columns)
+		}
+	}
+
+	var createSQL string
+	if err := s.db.QueryRow(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'tasks'`).Scan(&createSQL); err != nil {
+		t.Fatalf("read tasks schema from sqlite_master: %v", err)
+	}
+	for _, column := range []string{"task_mode", "review_pr_number"} {
+		if !containsColumnDDL(createSQL, column) {
+			t.Fatalf("tasks create statement is missing %q: %s", column, createSQL)
+		}
+	}
+}
+
+func containsColumnDDL(createSQL, column string) bool {
+	return strings.Contains(createSQL, fmt.Sprintf("%s ", column))
 }


### PR DESCRIPTION
## Summary
- move `task_mode` and `review_pr_number` into the primary `tasks` table creation SQL
- remove the post-create SQLite `ALTER TABLE` migration path and rename schema setup to `ensureSchema`
- add a store schema test and update docs to reflect the single-step schema bootstrap

## Why
- the schema should be created with the full column set up front instead of relying on embedded migrations for fresh databases
- this keeps the SQLite bootstrap aligned with the requested no-migrations approach and documents the intended maintenance pattern
