### PR TITLE
[backflow] clean up README structure and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,140 +1,134 @@
 # Backflow
 
-Background agent orchestrator that runs coding agents (Claude Code or Codex) in ephemeral Docker containers on AWS EC2 spot instances. POST a task (repo + prompt), get back a branch with commits and optionally a PR.
+Backflow is a background orchestrator for coding agents. It runs Claude Code or Codex inside ephemeral Docker containers, either locally or on AWS EC2 spot instances. You submit a repository plus instructions, and Backflow drives the task to a pushed branch and, if requested, an open pull request.
+
+## What Backflow Does
+
+- Runs code-generation tasks against a Git repository.
+- Runs review tasks against an existing pull request.
+- Stores task and instance state in SQLite.
+- Supports local Docker execution for development and EC2 spot execution for scale.
+- Can send task webhooks and optionally upload agent output to S3.
 
 ## Prerequisites
 
 - Go 1.24+
-- AWS CLI (configured with credentials)
 - Docker
-- `sqlite3` CLI (for `make db-status`)
+- `jq` (used by the helper scripts)
+- `sqlite3` CLI (used by `make db-status`)
+- AWS CLI with credentials configured if you plan to use EC2 mode
 
-## Local Development
+## Quick Start
 
-### Setup
+### Run Backflow Locally
+
+1. Copy the example environment file:
 
 ```bash
 cp .env.example .env
-# Edit .env — at minimum set ANTHROPIC_API_KEY and GITHUB_TOKEN
 ```
 
-For local-only development without AWS, set `BACKFLOW_MODE=local` in `.env`. This skips EC2 provisioning and runs containers on the local Docker daemon.
+2. Edit `.env`:
 
-### Build and Run
+- Set `GITHUB_TOKEN`.
+- Set `ANTHROPIC_API_KEY` if you want to use `claude_code`.
+- Set `OPENAI_API_KEY` if you want to use `codex`.
+- Set `BACKFLOW_MODE=local` to skip EC2 provisioning and use your local Docker daemon.
+
+3. Start the service:
 
 ```bash
-make build          # Compile to bin/backflow
-make run            # Build + run (auto-sources .env)
+make build
+make run
 ```
 
-Server starts on `http://localhost:8080`. The orchestrator poll loop and HTTP server run as concurrent goroutines.
+Backflow listens on `http://localhost:8080`.
 
-### Testing
+### Submit a Task
+
+The helper script creates PRs by default. Use `--no-pr` only if you want to skip PR creation.
 
 ```bash
-make test           # Run all tests (no cache)
-make lint           # go vet
+# Claude Code task
+./scripts/create-task.sh https://github.com/org/repo "Fix the login bug" \
+  --harness claude_code
 
-# Run a single test
-go test ./internal/store/ -run TestCreateTask -v
+# Codex task
+./scripts/create-task.sh https://github.com/org/repo "Add unit tests" \
+  --harness codex \
+  --budget 15 \
+  --branch add-tests \
+  --target-branch develop \
+  --pr-title "Add unit tests for auth flows"
 
-# Run tests for a specific package
-go test ./internal/api/ -v -count=1
+# Prompt from a file, with self-review
+./scripts/create-task.sh https://github.com/org/repo \
+  --plan prompts.md \
+  --self-review
 ```
 
-Tests create temporary SQLite databases that are cleaned up automatically. No external services needed.
+If you care about harness selection, pass `--harness` explicitly. The API/server default harness is `claude_code`; the helper script currently defaults to `codex`.
 
-### Build the Agent Image Locally
+### Review an Existing Pull Request
 
 ```bash
-make docker-build-local    # Single-arch build, no push
+./scripts/review-pr.sh https://github.com/org/repo 42 \
+  --prompt "Focus on correctness and regression risks"
 ```
 
-## Database
-
-Backflow uses SQLite in WAL mode. The database file location is configured via `BACKFLOW_DB_PATH` (default: `backflow.db` in the working directory).
-
-### Schema
-
-Two tables: `tasks` and `instances`. See `internal/store/sqlite.go` for the full schema.
-
-### Migrations
-
-There are no separate migration files. Schema is managed in `internal/store/sqlite.go` in the `migrate()` method. All DDL uses `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`, so it's safe to run on every startup.
-
-**To add a new column:**
-
-1. Add an `ALTER TABLE ... ADD COLUMN` statement to `migrate()` in `internal/store/sqlite.go`, wrapped in an idempotent check (SQLite will error if the column already exists, so ignore the error or check `pragma table_info` first).
-2. Update the `INSERT`, `UPDATE`, and `SELECT` statements in the same file.
-3. Update the model struct in `internal/models/`.
-
-**To inspect the database:**
+## Common Commands
 
 ```bash
-make db-status                              # Dump all tasks and instances
-sqlite3 backflow.db ".schema"               # Show schema
-sqlite3 backflow.db "SELECT id, status, created_at FROM tasks ORDER BY created_at DESC LIMIT 10;"
+make test                # Run all tests
+make lint                # go vet
+make docker-build-local  # Build the agent image locally
+make db-status           # Show tasks and instances from SQLite
 ```
 
-**To reset the database:** delete the `backflow.db` file. It will be recreated on next startup.
+Tests create temporary SQLite databases and do not require external services.
 
-## AWS Setup (EC2 Mode)
+## Running on AWS
 
-### One-Time Infrastructure
+### One-Time Setup
 
 ```bash
 make setup-aws
 ```
 
-This creates: ECR repo, IAM role, security group, and launch template. Copy the `BACKFLOW_LAUNCH_TEMPLATE_ID` from the output into `.env`.
+This provisions the supporting AWS resources, including an ECR repository, IAM role, security group, and launch template. Copy the emitted `BACKFLOW_LAUNCH_TEMPLATE_ID` into `.env`.
 
-### Deploy Agent Image
+If you are not using a launch template, Backflow can also boot EC2 instances from `BACKFLOW_AMI`, but one of `BACKFLOW_LAUNCH_TEMPLATE_ID` or `BACKFLOW_AMI` must be set in EC2 mode.
+
+### Build and Push the Agent Image
 
 ```bash
 make docker-deploy
-# If docker needs sudo: make docker-deploy DOCKER="sudo docker"
+# If Docker requires sudo:
+make docker-deploy DOCKER="sudo docker"
 ```
 
-Builds a multi-arch image (amd64 + arm64) and pushes to ECR.
+This builds a multi-architecture image and pushes it to ECR.
 
-## Submitting Tasks
+## API Usage
 
-```bash
-# Simple task
-./scripts/create-task.sh https://github.com/org/repo "Fix the login bug"
-
-# With PR creation
-./scripts/create-task.sh https://github.com/org/repo "Fix the login bug" --pr
-
-# Full options
-./scripts/create-task.sh https://github.com/org/repo "Add unit tests" \
-  --pr --pr-title "Add tests" \
-  --budget 15 --model claude-sonnet-4-6 \
-  --branch my-feature --target-branch develop \
-  --context "Focus on the auth module" \
-  --claude-md "Always use table-driven tests" \
-  --env "GOPRIVATE=github.com/org/*"
-```
-
-Or call the API directly:
+### Create a Task
 
 ```bash
-# Claude Code (default)
 curl -X POST http://localhost:8080/api/v1/tasks \
   -H "Content-Type: application/json" \
-  -d '{"repo_url": "https://github.com/org/repo", "prompt": "Fix the bug", "create_pr": true}'
-
-# Codex (requires OPENAI_API_KEY)
-curl -X POST http://localhost:8080/api/v1/tasks \
-  -H "Content-Type: application/json" \
-  -d '{"repo_url": "https://github.com/org/repo", "prompt": "Fix the bug", "harness": "codex", "create_pr": true}'
+  -d '{
+    "repo_url": "https://github.com/org/repo",
+    "prompt": "Fix the bug",
+    "harness": "claude_code",
+    "create_pr": true
+  }'
 ```
 
-## Monitoring and Operations
+### Monitor a Task
 
 ```bash
-# Database state
-make db-status
+# Health
+curl http://localhost:8080/api/v1/health
 
 # Task details
 curl http://localhost:8080/api/v1/tasks/{id}
@@ -142,22 +136,11 @@ curl http://localhost:8080/api/v1/tasks/{id}
 # Container logs
 curl http://localhost:8080/api/v1/tasks/{id}/logs?tail=100
 
-# Health check
-curl http://localhost:8080/api/v1/health
-
-# Shell into an agent EC2 instance
-aws ssm start-session --target i-0abc...
+# Cancel a task
+curl -X DELETE http://localhost:8080/api/v1/tasks/{id}
 ```
 
-### Task Lifecycle
-
-`pending` → `provisioning` → `running` → `completed` | `failed` | `interrupted` | `cancelled`
-
-### Instance Lifecycle
-
-`pending` → `running` → idle 5 min → `terminated`. Spot interruptions automatically re-queue affected tasks.
-
-## API Reference
+### Endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -165,26 +148,56 @@ aws ssm start-session --target i-0abc...
 | `GET` | `/api/v1/tasks` | List tasks (`?status=`, `?limit=`, `?offset=`) |
 | `GET` | `/api/v1/tasks/{id}` | Get task details |
 | `DELETE` | `/api/v1/tasks/{id}` | Cancel a task |
-| `GET` | `/api/v1/tasks/{id}/logs` | Container logs (`?tail=100`) |
+| `GET` | `/api/v1/tasks/{id}/logs` | Fetch task logs (`?tail=100`) |
 | `GET` | `/api/v1/health` | Health check |
 
-## Auth Modes
+## Task and Instance Lifecycle
 
-- **`api_key`** (default) — Uses Anthropic API key. Supports multiple concurrent agents. Pay per token.
-- **`max_subscription`** — Uses Claude Max subscription credentials. One agent at a time. Flat rate.
+### Task States
 
-## Harnesses
+`pending` -> `provisioning` -> `running` -> `completed` | `failed` | `interrupted` | `cancelled`
 
-Tasks can run with different agent CLIs via the `harness` field:
+Spot interruptions can also move a task through `recovering` before it is re-queued.
 
-- **`claude_code`** (default) — Claude Code CLI. Uses `--output-format stream-json` with retry logic and structured result parsing.
-- **`codex`** — OpenAI Codex CLI. Uses `--full-auto --quiet` mode. Requires `OPENAI_API_KEY`.
+### Instance States
 
-Set `BACKFLOW_DEFAULT_HARNESS` to change the default, or specify per-task in the API request.
+`pending` -> `running` -> idle for 5 minutes -> `terminated`
+
+## Harnesses and Auth Modes
+
+### Harnesses
+
+- `claude_code`: Claude Code CLI
+- `codex`: OpenAI Codex CLI
+
+Set `BACKFLOW_DEFAULT_HARNESS` to change the server default, or choose a harness per task with the `harness` field or `--harness`.
+
+### Auth Modes
+
+- `api_key`: Uses Anthropic API credentials and supports multiple concurrent agents
+- `max_subscription`: Uses Claude Max subscription credentials and limits execution to one agent at a time
+
+## Database
+
+Backflow uses SQLite in WAL mode. The database path is controlled by `BACKFLOW_DB_PATH` and defaults to `backflow.db`.
+
+Schema management is handled directly in `internal/store/sqlite.go` via idempotent DDL in `migrate()`. There are no standalone migration files.
+
+Useful commands:
+
+```bash
+make db-status
+sqlite3 backflow.db ".schema"
+sqlite3 backflow.db "SELECT id, status, created_at FROM tasks ORDER BY created_at DESC LIMIT 10;"
+```
+
+To reset the local database, delete `backflow.db` and restart the service.
 
 ## Webhooks
 
-Set `BACKFLOW_WEBHOOK_URL` in `.env`:
+Set `BACKFLOW_WEBHOOK_URL` to receive task events. You can optionally filter which events are sent with `BACKFLOW_WEBHOOK_EVENTS`.
+
+Example payload:
 
 ```json
 {
@@ -198,38 +211,39 @@ Set `BACKFLOW_WEBHOOK_URL` in `.env`:
 }
 ```
 
-Events: `task.created`, `task.running`, `task.completed`, `task.failed`, `task.needs_input`, `task.interrupted`
-
-Filter with `BACKFLOW_WEBHOOK_EVENTS=task.completed,task.failed`.
+Supported events: `task.created`, `task.running`, `task.completed`, `task.failed`, `task.needs_input`, `task.interrupted`
 
 ## Configuration
 
-All config is via environment variables (or `.env` file).
+Backflow is configured through environment variables, usually via `.env`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BACKFLOW_MODE` | `ec2` | `ec2` or `local` |
-| `BACKFLOW_AUTH_MODE` | `api_key` | `api_key` or `max_subscription` |
-| `ANTHROPIC_API_KEY` | | Required for `api_key` mode |
-| `OPENAI_API_KEY` | | Required for `codex` harness |
+| `BACKFLOW_MODE` | `ec2` | Execution mode: `ec2` or `local` |
+| `BACKFLOW_AUTH_MODE` | `api_key` | Auth mode: `api_key` or `max_subscription` |
+| `ANTHROPIC_API_KEY` | | Required when using `api_key` mode |
+| `OPENAI_API_KEY` | | Required for the `codex` harness |
 | `CLAUDE_CREDENTIALS_PATH` | | Path to `~/.claude/` for `max_subscription` mode |
-| `GITHUB_TOKEN` | | For cloning private repos and creating PRs |
-| `BACKFLOW_LISTEN_ADDR` | `:8080` | Server listen address |
+| `GITHUB_TOKEN` | | Used for cloning private repositories and creating PRs |
+| `BACKFLOW_LISTEN_ADDR` | `:8080` | HTTP listen address |
 | `BACKFLOW_DB_PATH` | `backflow.db` | SQLite database path |
 | `AWS_REGION` | `us-east-1` | AWS region |
 | `BACKFLOW_INSTANCE_TYPE` | `m7g.xlarge` | EC2 instance type |
-| `BACKFLOW_LAUNCH_TEMPLATE_ID` | | From `make setup-aws` |
-| `BACKFLOW_MAX_INSTANCES` | `5` | Max EC2 instances |
+| `BACKFLOW_LAUNCH_TEMPLATE_ID` | | Launch template ID for EC2 mode |
+| `BACKFLOW_AMI` | | Optional AMI override for EC2 mode |
+| `BACKFLOW_MAX_INSTANCES` | `5` | Maximum EC2 instances |
 | `BACKFLOW_CONTAINERS_PER_INSTANCE` | `1` | Containers per instance |
 | `BACKFLOW_CONTAINER_CPUS` | `2` | CPU cores per container |
-| `BACKFLOW_CONTAINER_MEMORY_GB` | `8` | Memory (GB) per container |
-| `BACKFLOW_DEFAULT_HARNESS` | `claude_code` | Default harness (`claude_code` or `codex`) |
-| `BACKFLOW_DEFAULT_MODEL` | `claude-sonnet-4-6` | Default model for Claude Code harness |
-| `BACKFLOW_DEFAULT_CODEX_MODEL` | `gpt-5.4` | Default model for Codex harness |
-| `BACKFLOW_DEFAULT_MAX_BUDGET` | `10` | Default budget (USD) |
-| `BACKFLOW_DEFAULT_MAX_RUNTIME_MIN` | `30` | Default max runtime (min) |
-| `BACKFLOW_DEFAULT_MAX_TURNS` | `200` | Default max turns |
+| `BACKFLOW_CONTAINER_MEMORY_GB` | `8` | Memory in GB per container |
+| `BACKFLOW_S3_BUCKET` | | Optional S3 bucket for saved agent output |
+| `BACKFLOW_DEFAULT_HARNESS` | `claude_code` | Default server-side harness |
+| `BACKFLOW_DEFAULT_MODEL` | `claude-sonnet-4-6` | Default model for `claude_code` |
+| `BACKFLOW_DEFAULT_CODEX_MODEL` | `gpt-5.4` | Default model for `codex` |
+| `BACKFLOW_DEFAULT_EFFORT` | `high` | Default reasoning effort |
+| `BACKFLOW_DEFAULT_MAX_BUDGET` | `10` | Default budget in USD |
+| `BACKFLOW_DEFAULT_MAX_RUNTIME_MIN` | `30` | Default max runtime in minutes |
+| `BACKFLOW_DEFAULT_MAX_TURNS` | `200` | Default max conversation turns |
 | `BACKFLOW_WEBHOOK_URL` | | Webhook endpoint |
-| `BACKFLOW_WEBHOOK_EVENTS` | all | Comma-separated event filter |
-| `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator poll interval (sec) |
-| `DOCKER` | `docker` | Docker command (e.g. `sudo docker`) |
+| `BACKFLOW_WEBHOOK_EVENTS` | all | Comma-separated webhook event filter |
+| `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator poll interval in seconds |
+| `DOCKER` | `docker` | Docker command override, for example `sudo docker` |


### PR DESCRIPTION
## Summary
- reorganize the README around a faster quick-start workflow
- correct task submission examples to match the helper scripts and current defaults
- add missing operational details, including config variables and lifecycle notes

## Why
The previous README mixed setup, operations, and reference material together and included a few inaccurate examples. This update makes the main workflows easier to follow and brings the documentation back in line with the current code and scripts.