### PR TITLE
[backflow] Reorganize README for clearer setup and operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,190 +1,223 @@
 # Backflow
 
-Background agent orchestrator that runs coding agents (Claude Code or Codex) in ephemeral Docker containers on AWS EC2 spot instances. POST a task (repo + prompt), get back a branch with commits and optionally a PR.
+Backflow is a background agent orchestrator for repository tasks. You submit a repo URL and prompt, Backflow runs a coding agent in an ephemeral Docker container, and you get back a branch with commits and, optionally, a pull request.
 
-## Prerequisites
+It supports:
+
+- Local execution on the current Docker host for development
+- AWS EC2 spot instances for remote execution
+- Multiple harnesses, including Claude Code and Codex
+- Webhook notifications and optional agent-output storage
+
+## How It Works
+
+1. A client submits a task over HTTP or via `scripts/create-task.sh`.
+2. Backflow provisions an execution environment in `local` or `ec2` mode.
+3. The selected harness runs against the target repository and prompt.
+4. Backflow tracks task state, stores logs and metadata in SQLite, and can open a PR on completion.
+
+## Requirements
 
 - Go 1.24+
-- AWS CLI (configured with credentials)
 - Docker
-- `sqlite3` CLI (for `make db-status`)
+- `jq` for `scripts/create-task.sh`
+- `sqlite3` CLI for `make db-status`
+- AWS CLI with configured credentials if you want to use EC2 mode
 
-## Local Development
+## Quick Start
 
-### Setup
+For the shortest path, run Backflow in local mode.
+
+### 1. Configure environment variables
 
 ```bash
 cp .env.example .env
-# Edit .env — at minimum set ANTHROPIC_API_KEY and GITHUB_TOKEN
 ```
 
-For local-only development without AWS, set `BACKFLOW_MODE=local` in `.env`. This skips EC2 provisioning and runs containers on the local Docker daemon.
+Edit `.env` and set:
 
-### Build and Run
+- `BACKFLOW_MODE=local`
+- `ANTHROPIC_API_KEY` if you want to run Claude Code tasks
+- `OPENAI_API_KEY` if you want to run Codex tasks
+- `GITHUB_TOKEN` if tasks need private repo access or PR creation
+
+### 2. Build and run
 
 ```bash
-make build          # Compile to bin/backflow
-make run            # Build + run (auto-sources .env)
+make build
+make run
 ```
 
-Server starts on `http://localhost:8080`. The orchestrator poll loop and HTTP server run as concurrent goroutines.
+The API listens on `http://localhost:8080`.
 
-### Testing
+### 3. Submit a task
 
 ```bash
-make test           # Run all tests (no cache)
-make lint           # go vet
-
-# Run a single test
-go test ./internal/store/ -run TestCreateTask -v
-
-# Run tests for a specific package
-go test ./internal/api/ -v -count=1
+./scripts/create-task.sh https://github.com/org/repo "Fix the login bug" \
+  --harness codex
 ```
 
-Tests create temporary SQLite databases that are cleaned up automatically. No external services needed.
-
-### Build the Agent Image Locally
+## Common Commands
 
 ```bash
-make docker-build-local    # Single-arch build, no push
+make build               # Build bin/backflow
+make run                 # Build and run with .env loaded
+make test                # Run all tests without cache
+make lint                # Run go vet
+make docker-build-local  # Build the agent image locally
+make db-status           # Inspect tasks and instances in SQLite
 ```
-
-## Database
-
-Backflow uses SQLite in WAL mode. The database file location is configured via `BACKFLOW_DB_PATH` (default: `backflow.db` in the working directory).
-
-### Schema
-
-Two tables: `tasks` and `instances`. See `internal/store/sqlite.go` for the full schema.
-
-### Migrations
-
-There are no separate migration files. Schema is managed in `internal/store/sqlite.go` in the `migrate()` method. All DDL uses `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`, so it's safe to run on every startup.
-
-**To add a new column:**
-
-1. Add an `ALTER TABLE ... ADD COLUMN` statement to `migrate()` in `internal/store/sqlite.go`, wrapped in an idempotent check (SQLite will error if the column already exists, so ignore the error or check `pragma table_info` first).
-2. Update the `INSERT`, `UPDATE`, and `SELECT` statements in the same file.
-3. Update the model struct in `internal/models/`.
-
-**To inspect the database:**
-
-```bash
-make db-status                              # Dump all tasks and instances
-sqlite3 backflow.db ".schema"               # Show schema
-sqlite3 backflow.db "SELECT id, status, created_at FROM tasks ORDER BY created_at DESC LIMIT 10;"
-```
-
-**To reset the database:** delete the `backflow.db` file. It will be recreated on next startup.
-
-## AWS Setup (EC2 Mode)
-
-### One-Time Infrastructure
-
-```bash
-make setup-aws
-```
-
-This creates: ECR repo, IAM role, security group, and launch template. Copy the `BACKFLOW_LAUNCH_TEMPLATE_ID` from the output into `.env`.
-
-### Deploy Agent Image
-
-```bash
-make docker-deploy
-# If docker needs sudo: make docker-deploy DOCKER="sudo docker"
-```
-
-Builds a multi-arch image (amd64 + arm64) and pushes to ECR.
 
 ## Submitting Tasks
+
+The helper script is the easiest way to create tasks. Its default harness is `codex`; pass `--harness claude_code` to run Claude Code instead. Pull request creation is enabled by default; use `--no-pr` to skip it.
 
 ```bash
 # Simple task
 ./scripts/create-task.sh https://github.com/org/repo "Fix the login bug"
 
-# With PR creation
-./scripts/create-task.sh https://github.com/org/repo "Fix the login bug" --pr
+# Claude Code task
+./scripts/create-task.sh https://github.com/org/repo "Add tests for auth flows" \
+  --harness claude_code \
+  --model claude-sonnet-4-6
 
-# Full options
-./scripts/create-task.sh https://github.com/org/repo "Add unit tests" \
-  --pr --pr-title "Add tests" \
-  --budget 15 --model claude-sonnet-4-6 \
-  --branch my-feature --target-branch develop \
-  --context "Focus on the auth module" \
-  --claude-md "Always use table-driven tests" \
-  --env "GOPRIVATE=github.com/org/*"
+# Task from a plan file
+./scripts/create-task.sh https://github.com/org/repo --plan plan.md \
+  --branch feature/refactor-auth \
+  --target-branch develop \
+  --budget 15 \
+  --effort high
 ```
 
-Or call the API directly:
+You can also call the API directly. If the request omits `harness`, the server default is `claude_code` unless overridden by `BACKFLOW_DEFAULT_HARNESS`.
 
 ```bash
-# Claude Code (default)
 curl -X POST http://localhost:8080/api/v1/tasks \
   -H "Content-Type: application/json" \
-  -d '{"repo_url": "https://github.com/org/repo", "prompt": "Fix the bug", "create_pr": true}'
-
-# Codex (requires OPENAI_API_KEY)
-curl -X POST http://localhost:8080/api/v1/tasks \
-  -H "Content-Type: application/json" \
-  -d '{"repo_url": "https://github.com/org/repo", "prompt": "Fix the bug", "harness": "codex", "create_pr": true}'
+  -d '{
+    "repo_url": "https://github.com/org/repo",
+    "prompt": "Fix the bug",
+    "create_pr": true
+  }'
 ```
 
-## Monitoring and Operations
+Codex example:
 
 ```bash
-# Database state
-make db-status
+curl -X POST http://localhost:8080/api/v1/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "repo_url": "https://github.com/org/repo",
+    "prompt": "Fix the bug",
+    "harness": "codex",
+    "create_pr": true
+  }'
+```
+
+## Deployment Modes
+
+### Local mode
+
+Set `BACKFLOW_MODE=local` to skip EC2 provisioning and run containers on the local Docker daemon. This is the recommended mode for development.
+
+### EC2 mode
+
+EC2 mode runs agent containers on AWS spot instances.
+
+One-time setup:
+
+```bash
+make setup-aws
+```
+
+That creates the supporting AWS resources and prints a launch template ID. Put that value in `.env` as `BACKFLOW_LAUNCH_TEMPLATE_ID`.
+
+To build and push the agent image to ECR:
+
+```bash
+make docker-deploy
+```
+
+If Docker requires `sudo` on your machine:
+
+```bash
+make docker-deploy DOCKER="sudo docker"
+```
+
+## Operations
+
+### Task lifecycle
+
+`pending` -> `provisioning` -> `running` -> `completed` | `failed` | `interrupted` | `cancelled`
+
+### Instance lifecycle
+
+`pending` -> `running` -> idle for 5 minutes -> `terminated`
+
+Spot interruptions automatically re-queue affected tasks.
+
+### Useful API calls
+
+```bash
+# Health
+curl http://localhost:8080/api/v1/health
 
 # Task details
 curl http://localhost:8080/api/v1/tasks/{id}
 
-# Container logs
+# Task logs
 curl http://localhost:8080/api/v1/tasks/{id}/logs?tail=100
 
-# Health check
-curl http://localhost:8080/api/v1/health
-
-# Shell into an agent EC2 instance
-aws ssm start-session --target i-0abc...
+# Cancel a task
+curl -X DELETE http://localhost:8080/api/v1/tasks/{id}
 ```
 
-### Task Lifecycle
-
-`pending` → `provisioning` → `running` → `completed` | `failed` | `interrupted` | `cancelled`
-
-### Instance Lifecycle
-
-`pending` → `running` → idle 5 min → `terminated`. Spot interruptions automatically re-queue affected tasks.
-
-## API Reference
+### API reference
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/api/v1/tasks` | Create a task |
-| `GET` | `/api/v1/tasks` | List tasks (`?status=`, `?limit=`, `?offset=`) |
+| `GET` | `/api/v1/tasks` | List tasks with `status`, `limit`, and `offset` filters |
 | `GET` | `/api/v1/tasks/{id}` | Get task details |
 | `DELETE` | `/api/v1/tasks/{id}` | Cancel a task |
-| `GET` | `/api/v1/tasks/{id}/logs` | Container logs (`?tail=100`) |
+| `GET` | `/api/v1/tasks/{id}/logs` | Read container logs |
 | `GET` | `/api/v1/health` | Health check |
 
-## Auth Modes
+## Harnesses and Auth
 
-- **`api_key`** (default) — Uses Anthropic API key. Supports multiple concurrent agents. Pay per token.
-- **`max_subscription`** — Uses Claude Max subscription credentials. One agent at a time. Flat rate.
+Supported harnesses:
 
-## Harnesses
+- `claude_code`: Claude Code CLI
+- `codex`: OpenAI Codex CLI
 
-Tasks can run with different agent CLIs via the `harness` field:
+Auth modes:
 
-- **`claude_code`** (default) — Claude Code CLI. Uses `--output-format stream-json` with retry logic and structured result parsing.
-- **`codex`** — OpenAI Codex CLI. Uses `--full-auto --quiet` mode. Requires `OPENAI_API_KEY`.
+- `api_key`: uses API keys and supports concurrent agents
+- `max_subscription`: uses Claude Max credentials and runs one agent at a time
 
-Set `BACKFLOW_DEFAULT_HARNESS` to change the default, or specify per-task in the API request.
+## Database
+
+Backflow uses SQLite in WAL mode. The database path is controlled by `BACKFLOW_DB_PATH` and defaults to `backflow.db`.
+
+- Schema and migration logic live in `internal/store/sqlite.go`
+- Main tables are `tasks` and `instances`
+- The schema is applied on startup with idempotent `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` statements
+
+Useful commands:
+
+```bash
+make db-status
+sqlite3 backflow.db ".schema"
+sqlite3 backflow.db "SELECT id, status, created_at FROM tasks ORDER BY created_at DESC LIMIT 10;"
+```
+
+To reset local state, delete `backflow.db` and restart the server.
 
 ## Webhooks
 
-Set `BACKFLOW_WEBHOOK_URL` in `.env`:
+Set `BACKFLOW_WEBHOOK_URL` to receive task lifecycle events. Use `BACKFLOW_WEBHOOK_EVENTS` to limit which events are delivered.
+
+Example payload:
 
 ```json
 {
@@ -198,38 +231,51 @@ Set `BACKFLOW_WEBHOOK_URL` in `.env`:
 }
 ```
 
-Events: `task.created`, `task.running`, `task.completed`, `task.failed`, `task.needs_input`, `task.interrupted`
+Supported events:
 
-Filter with `BACKFLOW_WEBHOOK_EVENTS=task.completed,task.failed`.
+- `task.created`
+- `task.running`
+- `task.completed`
+- `task.failed`
+- `task.needs_input`
+- `task.interrupted`
 
 ## Configuration
 
-All config is via environment variables (or `.env` file).
+Backflow is configured entirely through environment variables. Start with `.env.example`; the most important variables are listed below.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `BACKFLOW_MODE` | `ec2` | `ec2` or `local` |
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `BACKFLOW_MODE` | `ec2` | Use `local` for local Docker execution |
 | `BACKFLOW_AUTH_MODE` | `api_key` | `api_key` or `max_subscription` |
-| `ANTHROPIC_API_KEY` | | Required for `api_key` mode |
-| `OPENAI_API_KEY` | | Required for `codex` harness |
-| `CLAUDE_CREDENTIALS_PATH` | | Path to `~/.claude/` for `max_subscription` mode |
-| `GITHUB_TOKEN` | | For cloning private repos and creating PRs |
-| `BACKFLOW_LISTEN_ADDR` | `:8080` | Server listen address |
+| `ANTHROPIC_API_KEY` | | Required for Claude Code in `api_key` mode |
+| `OPENAI_API_KEY` | | Required for Codex tasks |
+| `CLAUDE_CREDENTIALS_PATH` | | Required for `max_subscription` mode |
+| `GITHUB_TOKEN` | | Needed for private repo access and PR creation |
+| `BACKFLOW_LISTEN_ADDR` | `:8080` | HTTP listen address |
 | `BACKFLOW_DB_PATH` | `backflow.db` | SQLite database path |
-| `AWS_REGION` | `us-east-1` | AWS region |
+| `AWS_REGION` | `us-east-1` | AWS region for EC2 mode |
 | `BACKFLOW_INSTANCE_TYPE` | `m7g.xlarge` | EC2 instance type |
-| `BACKFLOW_LAUNCH_TEMPLATE_ID` | | From `make setup-aws` |
-| `BACKFLOW_MAX_INSTANCES` | `5` | Max EC2 instances |
-| `BACKFLOW_CONTAINERS_PER_INSTANCE` | `1` | Containers per instance |
+| `BACKFLOW_LAUNCH_TEMPLATE_ID` | | Required in EC2 mode after `make setup-aws` |
+| `BACKFLOW_MAX_INSTANCES` | `5` | Maximum EC2 instances |
+| `BACKFLOW_CONTAINERS_PER_INSTANCE` | `1` | Local mode also uses this value |
 | `BACKFLOW_CONTAINER_CPUS` | `2` | CPU cores per container |
-| `BACKFLOW_CONTAINER_MEMORY_GB` | `8` | Memory (GB) per container |
-| `BACKFLOW_DEFAULT_HARNESS` | `claude_code` | Default harness (`claude_code` or `codex`) |
-| `BACKFLOW_DEFAULT_MODEL` | `claude-sonnet-4-6` | Default model for Claude Code harness |
-| `BACKFLOW_DEFAULT_CODEX_MODEL` | `gpt-5.4` | Default model for Codex harness |
-| `BACKFLOW_DEFAULT_MAX_BUDGET` | `10` | Default budget (USD) |
-| `BACKFLOW_DEFAULT_MAX_RUNTIME_MIN` | `30` | Default max runtime (min) |
-| `BACKFLOW_DEFAULT_MAX_TURNS` | `200` | Default max turns |
+| `BACKFLOW_CONTAINER_MEMORY_GB` | `8` | Memory per container |
+| `BACKFLOW_DEFAULT_HARNESS` | `claude_code` | Server-side default harness |
+| `BACKFLOW_DEFAULT_MODEL` | `claude-sonnet-4-6` | Default Claude model |
+| `BACKFLOW_DEFAULT_CODEX_MODEL` | `gpt-5.4` | Default Codex model |
+| `BACKFLOW_DEFAULT_EFFORT` | `high` | Default reasoning effort |
+| `BACKFLOW_DEFAULT_MAX_BUDGET` | `10` | Budget in USD |
+| `BACKFLOW_DEFAULT_MAX_RUNTIME_MIN` | `30` | Runtime limit in minutes |
+| `BACKFLOW_DEFAULT_MAX_TURNS` | `200` | Maximum agent turns |
 | `BACKFLOW_WEBHOOK_URL` | | Webhook endpoint |
 | `BACKFLOW_WEBHOOK_EVENTS` | all | Comma-separated event filter |
-| `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator poll interval (sec) |
-| `DOCKER` | `docker` | Docker command (e.g. `sudo docker`) |
+| `BACKFLOW_S3_BUCKET` | | Optional agent-output storage bucket |
+| `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator polling interval |
+| `DOCKER` | `docker` | Docker command used by the Makefile |
+
+## Additional Docs
+
+- `docs/schema.md`
+- `docs/sizing.md`
+- `docs/file-reference.md`


### PR DESCRIPTION
## Summary
- reorganize the README around quick start, task submission, deployment, and operations
- add missing prerequisites and clarify harness and PR-creation behavior in the helper script examples
- tighten configuration, database, and webhook sections so key runtime details are easier to scan

## Why
The previous README had the right information, but the most common setup path was buried and some usage examples were inaccurate. This cleanup makes the repo easier to onboard into and reduces confusion around task submission defaults.