### PR TITLE
[backflow] Clean up README and fix create-task.sh defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,20 +100,23 @@ Builds a multi-arch image (amd64 + arm64) and pushes to ECR.
 ## Submitting Tasks
 
 ```bash
-# Simple task
+# Simple task (creates a PR by default)
 ./scripts/create-task.sh https://github.com/org/repo "Fix the login bug"
 
-# With PR creation
-./scripts/create-task.sh https://github.com/org/repo "Fix the login bug" --pr
+# Without PR creation
+./scripts/create-task.sh https://github.com/org/repo "Fix the login bug" --no-pr
 
 # Full options
 ./scripts/create-task.sh https://github.com/org/repo "Add unit tests" \
-  --pr --pr-title "Add tests" \
+  --pr-title "Add tests" \
   --budget 15 --model claude-sonnet-4-6 \
   --branch my-feature --target-branch develop \
   --context "Focus on the auth module" \
   --claude-md "Always use table-driven tests" \
   --env "GOPRIVATE=github.com/org/*"
+
+# Read prompt from a file
+./scripts/create-task.sh https://github.com/org/repo --plan plan.md --self-review
 ```
 
 Or call the API directly:
@@ -151,7 +154,9 @@ aws ssm start-session --target i-0abc...
 
 ### Task Lifecycle
 
-`pending` → `provisioning` → `running` → `completed` | `failed` | `interrupted` | `cancelled`
+`pending` → `provisioning` → `running` → `completed` | `failed` | `interrupted` | `cancelled` | `recovering`
+
+Tasks orphaned by a server restart enter `recovering`, then transition back to `pending` or `running`.
 
 ### Instance Lifecycle
 
@@ -198,7 +203,7 @@ Set `BACKFLOW_WEBHOOK_URL` in `.env`:
 }
 ```
 
-Events: `task.created`, `task.running`, `task.completed`, `task.failed`, `task.needs_input`, `task.interrupted`
+Events: `task.created`, `task.running`, `task.completed`, `task.failed`, `task.needs_input`, `task.interrupted`, `task.recovering`
 
 Filter with `BACKFLOW_WEBHOOK_EVENTS=task.completed,task.failed`.
 
@@ -218,6 +223,7 @@ All config is via environment variables (or `.env` file).
 | `BACKFLOW_DB_PATH` | `backflow.db` | SQLite database path |
 | `AWS_REGION` | `us-east-1` | AWS region |
 | `BACKFLOW_INSTANCE_TYPE` | `m7g.xlarge` | EC2 instance type |
+| `BACKFLOW_AMI` | | Custom AMI for EC2 instances |
 | `BACKFLOW_LAUNCH_TEMPLATE_ID` | | From `make setup-aws` |
 | `BACKFLOW_MAX_INSTANCES` | `5` | Max EC2 instances |
 | `BACKFLOW_CONTAINERS_PER_INSTANCE` | `1` | Containers per instance |
@@ -228,7 +234,9 @@ All config is via environment variables (or `.env` file).
 | `BACKFLOW_DEFAULT_CODEX_MODEL` | `gpt-5.4` | Default model for Codex harness |
 | `BACKFLOW_DEFAULT_MAX_BUDGET` | `10` | Default budget (USD) |
 | `BACKFLOW_DEFAULT_MAX_RUNTIME_MIN` | `30` | Default max runtime (min) |
+| `BACKFLOW_DEFAULT_EFFORT` | `high` | Default reasoning effort (`low`, `medium`, `high`) |
 | `BACKFLOW_DEFAULT_MAX_TURNS` | `200` | Default max turns |
+| `BACKFLOW_S3_BUCKET` | | S3 bucket for saving agent output |
 | `BACKFLOW_WEBHOOK_URL` | | Webhook endpoint |
 | `BACKFLOW_WEBHOOK_EVENTS` | all | Comma-separated event filter |
 | `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator poll interval (sec) |

--- a/scripts/create-task.sh
+++ b/scripts/create-task.sh
@@ -28,7 +28,7 @@ Options:
   --branch <name>         Working branch name
   --target-branch <name>  Target branch (default: main)
   --harness <name>        Agent harness: claude_code (default) or codex
-  --model <model>         Model to use (default: claude-opus-4-6 or gpt-5.4 for codex)
+  --model <model>         Model to use (default: claude-sonnet-4-6 or gpt-5.4 for codex)
   --effort <level>        Reasoning effort: low, medium, high (default: high)
   --budget <usd>          Max budget in USD
   --runtime <min>         Max runtime in minutes
@@ -61,7 +61,7 @@ else
 fi
 
 # Defaults
-HARNESS="codex"
+HARNESS="claude_code"
 BRANCH=""
 TARGET_BRANCH=""
 MODEL=""


### PR DESCRIPTION
## Summary
- Add missing `recovering` task status to lifecycle diagram and `task.recovering` to webhook events list
- Fix script examples: PR is created by default, so show `--no-pr` flag instead of nonexistent `--pr`; add `--plan` example
- Add undocumented config vars to the table: `BACKFLOW_DEFAULT_EFFORT`, `BACKFLOW_S3_BUCKET`, `BACKFLOW_AMI`
- Fix `create-task.sh` default harness from `codex` to `claude_code` (matching `internal/config/` default)
- Fix `create-task.sh` help text model name from `claude-opus-4-6` to `claude-sonnet-4-6`

## Test plan
- [ ] Verify `./scripts/create-task.sh --help` shows correct defaults
- [ ] Confirm README config table matches `internal/config/config.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)