### PR TITLE
Update README to match current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,188 +1,102 @@
 # Backflow
 
-Background agent orchestrator that runs coding agents (Claude Code or Codex) in ephemeral containers. POST a task (repo + prompt), get back a branch with commits and optionally a PR. Three operating modes: EC2 spot instances, local Docker, or ECS Fargate.
+Agent orchestrator that runs coding agents (Claude Code or Codex) in ephemeral containers. POST a task (repo + prompt), get back a branch with commits and a PR. Three modes: EC2 spot instances, local Docker, or ECS Fargate.
 
 ## Prerequisites
 
 - Go 1.24+
-- AWS CLI (configured with credentials)
 - Docker
-- `sqlite3` CLI (for `make db-status`)
+- `jq` (for helper scripts)
+- AWS CLI (for EC2/Fargate modes)
 
 ## Local Development
-
-### Setup
 
 ```bash
 cp .env.example .env
 # Edit .env — at minimum set ANTHROPIC_API_KEY and GITHUB_TOKEN
+# Set BACKFLOW_MODE=local for local Docker (no AWS needed)
 ```
-
-Set `BACKFLOW_MODE` in `.env`:
-- **`local`** — Runs containers on the local Docker daemon, no AWS needed
-- **`ec2`** (default) — Provisions EC2 spot instances
-- **`fargate`** — Runs each task as a standalone ECS Fargate task
-
-### Build and Run
 
 ```bash
 make build          # Compile to bin/backflow
 make run            # Build + run (auto-sources .env)
-```
-
-Server starts on `http://localhost:8080`. The orchestrator poll loop and HTTP server run as concurrent goroutines.
-
-### Testing
-
-```bash
 make test           # Run all tests (no cache)
 make lint           # go vet
-
-# Run a single test
-go test ./internal/store/ -run TestCreateTask -v
-
-# Run tests for a specific package
-go test ./internal/api/ -v -count=1
+make deps           # go mod tidy
+make clean          # Remove bin/
 ```
 
-Tests create temporary SQLite databases that are cleaned up automatically. No external services needed.
+Single test: `go test ./internal/store/ -run TestCreateTask -v`
 
-### Build the Agent Image Locally
-
-```bash
-make docker-build-local    # Single-arch build, no push
-```
-
-## Database
-
-Backflow uses SQLite in WAL mode. The database file location is configured via `BACKFLOW_DB_PATH` (default: `backflow.db` in the working directory).
-
-### Schema
-
-Two tables: `tasks` and `instances`. See `internal/store/sqlite.go` for the full schema.
-
-### Migrations
-
-There are no separate migration files. Schema is managed in `internal/store/sqlite.go` in the `migrate()` method. All DDL uses `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`, so it's safe to run on every startup.
-
-**To add a new column:**
-
-1. Add an `ALTER TABLE ... ADD COLUMN` statement to `migrate()` in `internal/store/sqlite.go`, wrapped in an idempotent check (SQLite will error if the column already exists, so ignore the error or check `pragma table_info` first).
-2. Update the `INSERT`, `UPDATE`, and `SELECT` statements in the same file.
-3. Update the model struct in `internal/models/`.
-
-**To inspect the database:**
-
-```bash
-make db-status                              # Dump all tasks and instances
-sqlite3 backflow.db ".schema"               # Show schema
-sqlite3 backflow.db "SELECT id, status, created_at FROM tasks ORDER BY created_at DESC LIMIT 10;"
-```
-
-**To reset the database:** delete the `backflow.db` file. It will be recreated on next startup.
-
-## AWS Setup (EC2 Mode)
-
-### One-Time Infrastructure
-
-```bash
-make setup-aws
-```
-
-This creates: ECR repo, IAM role, security group, and launch template. Copy the `BACKFLOW_LAUNCH_TEMPLATE_ID` from the output into `.env`.
-
-### Deploy Agent Image
-
-```bash
-make docker-deploy
-# If docker needs sudo: make docker-deploy DOCKER="sudo docker"
-```
-
-Builds a multi-arch image (amd64 + arm64) and pushes to ECR.
-
-## Fargate Mode
-
-Set `BACKFLOW_MODE=fargate` to run each task as a standalone ECS Fargate task. No EC2 instances to manage — capacity is tracked through a synthetic instance in SQLite.
-
-### Prerequisites
-
-- ECS cluster with Fargate capacity providers (include `FARGATE_SPOT` if using spot)
-- Task definition with `awslogs` log driver pointing to your CloudWatch log group
-- Subnets with egress for git/GitHub/API traffic
-- IAM execution and task roles for image pull, log delivery, and repo access
-
-### Quick start
-
-```bash
-# Add to .env
-BACKFLOW_MODE=fargate
-BACKFLOW_ECS_CLUSTER=backflow
-BACKFLOW_ECS_TASK_DEFINITION=backflow-agent
-BACKFLOW_ECS_SUBNETS=subnet-abc123,subnet-def456
-BACKFLOW_CLOUDWATCH_LOG_GROUP=/ecs/backflow
-```
-
-`max_subscription` auth is not supported in Fargate mode. Fargate Spot interruptions are detected and tasks are automatically re-queued.
+Tests create temporary SQLite databases — no external services needed.
 
 ## Submitting Tasks
 
+PRs are created by default. Use `--no-pr` to skip.
+
 ```bash
-# Simple task
+# Simple task (creates PR by default)
 ./scripts/create-task.sh https://github.com/org/repo "Fix the login bug"
 
-# With PR creation
-./scripts/create-task.sh https://github.com/org/repo "Fix the login bug" --pr
+# Skip PR creation
+./scripts/create-task.sh https://github.com/org/repo "Fix the login bug" --no-pr
 
-# Full options
+# With options
 ./scripts/create-task.sh https://github.com/org/repo "Add unit tests" \
-  --pr --pr-title "Add tests" \
-  --budget 15 --model claude-sonnet-4-6 \
+  --pr-title "Add tests" --budget 15 --model claude-sonnet-4-6 \
   --branch my-feature --target-branch develop \
   --context "Focus on the auth module" \
   --claude-md "Always use table-driven tests" \
+  --effort high --self-review
+
+# Prompt from a file
+./scripts/create-task.sh https://github.com/org/repo --plan plan.md
+
+# With env vars
+./scripts/create-task.sh https://github.com/org/repo "Fix bug" \
   --env "GOPRIVATE=github.com/org/*"
 ```
 
-Or call the API directly:
+### PR Reviews
 
 ```bash
-# Claude Code (default)
-curl -X POST http://localhost:8080/api/v1/tasks \
-  -H "Content-Type: application/json" \
-  -d '{"repo_url": "https://github.com/org/repo", "prompt": "Fix the bug", "create_pr": true}'
-
-# Codex (requires OPENAI_API_KEY)
-curl -X POST http://localhost:8080/api/v1/tasks \
-  -H "Content-Type: application/json" \
-  -d '{"repo_url": "https://github.com/org/repo", "prompt": "Fix the bug", "harness": "codex", "create_pr": true}'
+./scripts/review-pr.sh https://github.com/org/repo 42
+./scripts/review-pr.sh https://github.com/org/repo 42 --prompt "Focus on security issues"
+./scripts/review-pr.sh https://github.com/org/repo 42 --model claude-sonnet-4-6 --budget 5
 ```
 
-## Monitoring and Operations
+### Direct API
 
 ```bash
-# Database state
-make db-status
+# Create a coding task
+curl -X POST http://localhost:8080/api/v1/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "repo_url": "https://github.com/org/repo",
+    "prompt": "Fix the bug",
+    "create_pr": true,
+    "self_review": true
+  }'
 
-# Task details
-curl http://localhost:8080/api/v1/tasks/{id}
+# Review a PR
+curl -X POST http://localhost:8080/api/v1/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "repo_url": "https://github.com/org/repo",
+    "task_mode": "review",
+    "review_pr_number": 42
+  }'
 
-# Container logs
-curl http://localhost:8080/api/v1/tasks/{id}/logs?tail=100
-
-# Health check
-curl http://localhost:8080/api/v1/health
-
-# Shell into an agent EC2 instance
-aws ssm start-session --target i-0abc...
+# Codex harness (requires OPENAI_API_KEY)
+curl -X POST http://localhost:8080/api/v1/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "repo_url": "https://github.com/org/repo",
+    "prompt": "Fix the bug",
+    "harness": "codex",
+    "create_pr": true
+  }'
 ```
-
-### Task Lifecycle
-
-`pending` → `provisioning` → `running` → `completed` | `failed` | `interrupted` | `cancelled` | `recovering` → `pending` | `running` | `completed` | `failed`
-
-### Instance Lifecycle
-
-`pending` → `running` → `draining` → `terminated`. Spot interruptions (EC2 and Fargate Spot) automatically re-queue affected tasks.
 
 ## API Reference
 
@@ -195,43 +109,108 @@ aws ssm start-session --target i-0abc...
 | `GET` | `/api/v1/tasks/{id}/logs` | Container logs (`?tail=100`) |
 | `GET` | `/api/v1/health` | Health check |
 
-## Auth Modes
+### Task Request Fields
 
-- **`api_key`** (default) — Uses Anthropic API key. Supports multiple concurrent agents. Pay per token.
-- **`max_subscription`** — Uses Claude Max subscription credentials. One agent at a time. Flat rate.
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo_url` | string | **Required.** Repository URL |
+| `prompt` | string | **Required for code mode.** Agent instructions |
+| `task_mode` | string | `code` (default) or `review` |
+| `harness` | string | `claude_code` (default) or `codex` |
+| `model` | string | Model override (default: `claude-sonnet-4-6` / `gpt-5.4` for codex) |
+| `effort` | string | `low`, `medium`, `high` (default), or `xhigh` |
+| `branch` | string | Working branch name |
+| `target_branch` | string | Target branch (default: main) |
+| `create_pr` | bool | Create a PR on completion |
+| `self_review` | bool | Agent self-reviews the PR after creation |
+| `pr_title` | string | Custom PR title |
+| `pr_body` | string | Custom PR body |
+| `review_pr_number` | int | PR number (required for `review` mode) |
+| `max_budget_usd` | float | Budget cap in USD (default: 10) |
+| `max_runtime_min` | int | Runtime cap in minutes (default: 30) |
+| `max_turns` | int | Max conversation turns (default: 200) |
+| `context` | string | Additional context appended to prompt |
+| `claude_md` | string | Extra CLAUDE.md content injected into the repo |
+| `allowed_tools` | []string | Restrict agent tool access |
+| `env_vars` | map | Extra env vars passed to the container |
+| `save_agent_output` | bool | Save agent output to S3 (default: true if S3 configured) |
 
-## Harnesses
+## Monitoring and Operations
 
-Tasks can run with different agent CLIs via the `harness` field:
+```bash
+# Database state
+make db-status
 
-- **`claude_code`** (default) — Claude Code CLI. Uses `--output-format stream-json` with retry logic and structured result parsing.
-- **`codex`** — OpenAI Codex CLI. Uses `--full-auto --quiet` mode. Requires `OPENAI_API_KEY`.
+# Task details
+curl -s http://localhost:8080/api/v1/tasks/{id} | jq .
 
-Set `BACKFLOW_DEFAULT_HARNESS` to change the default, or specify per-task in the API request.
+# Container logs
+curl -s 'http://localhost:8080/api/v1/tasks/{id}/logs?tail=100'
 
-## Webhooks
+# Health check
+curl -s http://localhost:8080/api/v1/health
 
-Set `BACKFLOW_WEBHOOK_URL` in `.env`:
-
-```json
-{
-  "event": "task.completed",
-  "task_id": "bf_01KK...",
-  "repo_url": "https://github.com/org/repo",
-  "prompt": "Fix the bug",
-  "message": "",
-  "agent_log_tail": "last 20 lines...",
-  "timestamp": "2026-03-13T22:00:00Z"
-}
+# Shell into an agent EC2 instance
+aws ssm start-session --target i-0abc...
 ```
 
-Events: `task.created`, `task.running`, `task.completed`, `task.failed`, `task.needs_input`, `task.interrupted`, `task.recovering`
+### Task Lifecycle
 
-Filter with `BACKFLOW_WEBHOOK_EVENTS=task.completed,task.failed`.
+`pending` -> `provisioning` -> `running` -> `completed` | `failed` | `interrupted` | `cancelled`
+
+Interrupted/failed tasks can enter `recovering` -> re-queued as `pending`.
+
+### Database
+
+SQLite in WAL mode. Auto-migrates on startup. Configured via `BACKFLOW_DB_PATH` (default: `backflow.db`).
+
+```bash
+make db-status                              # Dump all tasks and instances
+sqlite3 backflow.db ".schema"               # Show schema
+sqlite3 backflow.db "SELECT id, status, created_at FROM tasks ORDER BY created_at DESC LIMIT 10;"
+```
+
+To reset: delete `backflow.db`. Recreated on next startup.
+
+To add a column: add an idempotent `ALTER TABLE` to `internal/store/sqlite.go:migrate()`, then update the model and queries.
+
+## Deployment
+
+### Agent Image
+
+```bash
+make docker-build-local    # Single-arch local build
+make docker-deploy         # Multi-arch build + push to ECR
+```
+
+### AWS Setup (EC2 Mode)
+
+```bash
+make setup-aws
+# Creates: ECR repo, IAM role, security group, launch template
+# Copy BACKFLOW_LAUNCH_TEMPLATE_ID from output into .env
+```
+
+### Fargate Mode
+
+Set `BACKFLOW_MODE=fargate`. No EC2 instances to manage.
+
+```bash
+# Required in .env
+BACKFLOW_MODE=fargate
+BACKFLOW_ECS_CLUSTER=backflow
+BACKFLOW_ECS_TASK_DEFINITION=backflow-agent
+BACKFLOW_ECS_SUBNETS=subnet-abc123,subnet-def456
+BACKFLOW_CLOUDWATCH_LOG_GROUP=/ecs/backflow
+```
+
+Prerequisites: ECS cluster with Fargate capacity providers, task definition with `awslogs` log driver, subnets with egress, IAM roles for image pull + log delivery.
+
+`max_subscription` auth is not supported in Fargate mode.
 
 ## Configuration
 
-All config is via environment variables (or `.env` file).
+All config via environment variables or `.env` file. See `.env.example` for the full list.
 
 ### General
 
@@ -241,26 +220,27 @@ All config is via environment variables (or `.env` file).
 | `BACKFLOW_AUTH_MODE` | `api_key` | `api_key` or `max_subscription` |
 | `ANTHROPIC_API_KEY` | | Required for `api_key` mode |
 | `OPENAI_API_KEY` | | Required for `codex` harness |
-| `CLAUDE_CREDENTIALS_PATH` | | Path to `~/.claude/` for `max_subscription` mode |
 | `GITHUB_TOKEN` | | For cloning private repos and creating PRs |
 | `BACKFLOW_LISTEN_ADDR` | `:8080` | Server listen address |
 | `BACKFLOW_DB_PATH` | `backflow.db` | SQLite database path |
-| `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator poll interval (sec) |
+| `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator poll interval (seconds) |
+| `BACKFLOW_S3_BUCKET` | | S3 bucket for agent output and large prompt offload |
 
-### Agent defaults
+### Agent Defaults
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BACKFLOW_DEFAULT_HARNESS` | `claude_code` | Default harness (`claude_code` or `codex`) |
-| `BACKFLOW_DEFAULT_MODEL` | `claude-sonnet-4-6` | Default model for Claude Code harness |
-| `BACKFLOW_DEFAULT_CODEX_MODEL` | `gpt-5.4` | Default model for Codex harness |
-| `BACKFLOW_DEFAULT_MAX_BUDGET` | `10` | Default budget (USD) |
-| `BACKFLOW_DEFAULT_MAX_RUNTIME_MIN` | `30` | Default max runtime (min) |
-| `BACKFLOW_DEFAULT_MAX_TURNS` | `200` | Default max turns |
+| `BACKFLOW_DEFAULT_HARNESS` | `claude_code` | `claude_code` or `codex` |
+| `BACKFLOW_DEFAULT_MODEL` | `claude-sonnet-4-6` | Default model for Claude Code |
+| `BACKFLOW_DEFAULT_CODEX_MODEL` | `gpt-5.4` | Default model for Codex |
+| `BACKFLOW_DEFAULT_EFFORT` | `high` | Reasoning effort (`low`, `medium`, `high`, `xhigh`) |
+| `BACKFLOW_DEFAULT_MAX_BUDGET` | `10` | Budget cap (USD) |
+| `BACKFLOW_DEFAULT_MAX_RUNTIME_MIN` | `30` | Runtime cap (minutes) |
+| `BACKFLOW_DEFAULT_MAX_TURNS` | `200` | Max conversation turns |
 | `BACKFLOW_CONTAINER_CPUS` | `2` | CPU cores per container |
 | `BACKFLOW_CONTAINER_MEMORY_GB` | `8` | Memory (GB) per container |
 
-### EC2 mode
+### EC2 Mode
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -269,27 +249,32 @@ All config is via environment variables (or `.env` file).
 | `BACKFLOW_LAUNCH_TEMPLATE_ID` | | From `make setup-aws` |
 | `BACKFLOW_MAX_INSTANCES` | `5` | Max EC2 instances |
 | `BACKFLOW_CONTAINERS_PER_INSTANCE` | `1` | Containers per instance |
-| `DOCKER` | `docker` | Docker command (e.g. `sudo docker`) |
 
-### Fargate mode
+### Fargate Mode
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `BACKFLOW_ECS_CLUSTER` | | ECS cluster name (required) |
-| `BACKFLOW_ECS_TASK_DEFINITION` | | ECS task definition ARN or family (required) |
+| `BACKFLOW_ECS_TASK_DEFINITION` | | Task definition ARN or family (required) |
 | `BACKFLOW_ECS_SUBNETS` | | Comma-separated subnet IDs (required) |
-| `BACKFLOW_CLOUDWATCH_LOG_GROUP` | | CloudWatch log group name (required) |
+| `BACKFLOW_CLOUDWATCH_LOG_GROUP` | | CloudWatch log group (required) |
 | `BACKFLOW_ECS_SECURITY_GROUPS` | | Comma-separated security group IDs |
 | `BACKFLOW_ECS_LAUNCH_TYPE` | `FARGATE_SPOT` | `FARGATE` or `FARGATE_SPOT` |
-| `BACKFLOW_ECS_CONTAINER_NAME` | `backflow-agent` | Main container name in task definition |
+| `BACKFLOW_ECS_CONTAINER_NAME` | `backflow-agent` | Container name in task definition |
 | `BACKFLOW_ECS_LOG_STREAM_PREFIX` | `ecs` | CloudWatch log stream prefix |
-| `BACKFLOW_ECS_ASSIGN_PUBLIC_IP` | `true` | Set `false` for private subnets with NAT |
+| `BACKFLOW_ECS_ASSIGN_PUBLIC_IP` | `true` | `false` for private subnets with NAT |
 | `BACKFLOW_MAX_CONCURRENT_TASKS` | `5` | Max concurrent Fargate tasks |
 
 ### Webhooks
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BACKFLOW_WEBHOOK_URL` | | Webhook endpoint |
+| `BACKFLOW_WEBHOOK_URL` | | Webhook endpoint URL |
 | `BACKFLOW_WEBHOOK_EVENTS` | all | Comma-separated event filter |
-| `BACKFLOW_S3_BUCKET` | | S3 bucket for task data (agent output, large prompt offload) |
+
+Events: `task.created`, `task.running`, `task.completed`, `task.failed`, `task.needs_input`, `task.interrupted`, `task.recovering`
+
+### Auth Modes
+
+- **`api_key`** (default) -- Anthropic API key, supports concurrent agents
+- **`max_subscription`** -- Claude Max credentials via `CLAUDE_CREDENTIALS_PATH`, one agent at a time, not supported in Fargate mode


### PR DESCRIPTION
## Summary
- Fix `create-task.sh` examples — PRs are on by default (`--no-pr` to skip), removed nonexistent `--pr` flag
- Add `review-pr.sh` docs and `review` task mode API example
- Add missing API request fields: `task_mode`, `effort`, `self_review`, `save_agent_output`, `allowed_tools`, `review_pr_number`
- Add `BACKFLOW_DEFAULT_EFFORT` to config table
- Reorganize sections: local dev → submitting tasks → API reference → monitoring → deployment → config

## Test plan
- [ ] Verify all `create-task.sh` flags match the script
- [ ] Verify config defaults match `internal/config/config.go`
- [ ] Verify API fields match `internal/models/task.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)