### PR TITLE
[backflow] Add CI workflow for build, test, lint, and fmt checks

### DIFF
--- a/.github/workflows-pending/ci.yml
+++ b/.github/workflows-pending/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+      - name: Format check
+        run: |
+          gofmt -l .
+          test -z "$(gofmt -l .)"


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions CI workflow that runs on pull requests targeting `main`
- The workflow runs four checks: **build**, **test**, **lint** (`go vet`), and **format** (`gofmt`)
- Uses `go-version-file: go.mod` to match the project's Go version

## Action required

The workflow file is at `.github/workflows-pending/ci.yml` because the automation token lacks the `workflow` scope needed to push files to `.github/workflows/`. To activate CI:

1. Move (or copy) `.github/workflows-pending/ci.yml` → `.github/workflows/ci.yml`
2. Delete the `.github/workflows-pending/` directory

This can be done via the GitHub web UI file editor or with a token that has the `workflow` scope.

## Workflow details

```yaml
name: CI

on:
  pull_request:
    branches: [main]

jobs:
  ci:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-go@v5
        with:
          go-version-file: go.mod
      - name: Build
        run: make build
      - name: Test
        run: make test
      - name: Lint
        run: make lint
      - name: Format check
        run: |
          gofmt -l .
          test -z "$(gofmt -l .)"
```

## Test plan

- [ ] Move file to `.github/workflows/ci.yml`
- [ ] Open a test PR and verify all four checks (build, test, lint, fmt) run and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)