### PR TITLE
[backflow] Improve GHA Docker deploy workflow with SHA tags and concurrency control

### DIFF
--- a/deploy/docker-deploy.yml
+++ b/deploy/docker-deploy.yml
@@ -1,0 +1,52 @@
+name: Build and Deploy Agent Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docker/**"
+
+concurrency:
+  group: docker-deploy
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: backflow-agent
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
+            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds git SHA image tag alongside `latest` for traceability and rollback capability
- Adds `concurrency` block to cancel stale builds when multiple pushes land in quick succession
- Fixes missing trailing newline

Builds on the workflow introduced in #62 — see [review comment](https://github.com/backflow-labs/backflow/pull/62) for detailed rationale.

## Test plan

- [ ] Move `deploy/docker-deploy.yml` → `.github/workflows/docker-deploy.yml` (requires `workflow` scope token)
- [ ] Configure `AWS_ROLE_ARN` secret in repo settings
- [ ] Merge to main with a change in `docker/` and verify the workflow runs
- [ ] Confirm images appear in ECR with both `latest` and SHA tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)