### PR TITLE
Add workflow_dispatch trigger to Docker deploy workflow

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "docker/**"
+  workflow_dispatch:
 
 env:
   AWS_REGION: us-east-1


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the Docker image build/deploy workflow, enabling manual runs from the GitHub Actions UI

## Test plan

- [ ] Verify workflow appears with "Run workflow" button in GitHub Actions UI
- [ ] Trigger a manual run and confirm it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)