### PR TITLE
[backflow] Add CI workflow for PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "Files not formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Lint
+        run: go vet ./...
+
+      - name: Build
+        run: go build -trimpath -o bin/backflow ./cmd/backflow
+
+      - name: Test
+        run: go test ./... -v -count=1


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs on PRs and pushes to `main`
- Checks: `gofmt` formatting, `go vet` lint, build, and `go test` with verbose output
- Uses `go-version-file: go.mod` to stay in sync with the project's Go version

## Test plan
- [ ] Open a PR and verify the CI workflow triggers
- [ ] Confirm all four steps (fmt, lint, build, test) pass on a clean branch
- [ ] Introduce a formatting issue and verify the check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)