### PR TITLE
[backflow] Add CI workflow for PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.1"
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Build
+        run: make build
+
+      - name: Lint
+        run: make lint
+
+      - name: Test
+        run: make test


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs on pull requests targeting `main`
- Checks include: `gofmt` formatting verification, `make build`, `make lint` (go vet), and `make test`
- Uses Go 1.24.1 to match the project's go.mod

## Test plan
- [ ] Open a PR and verify the CI workflow triggers
- [ ] Confirm all four steps (fmt, build, lint, test) pass on a clean branch
- [ ] Verify a PR with unformatted Go code fails the formatting check

🤖 Generated with [Claude Code](https://claude.com/claude-code)