### PR TITLE
[backflow] Enable Go caching in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Check formatting
         run: |


### PR DESCRIPTION
## Summary
- Enable Go module and build caching in the CI workflow by adding `cache: true` to `actions/setup-go@v5`
- This caches `~/go/pkg/mod` (module downloads) and `~/.cache/go-build` (build artifacts) between runs, keyed on `go.sum`
- The Docker deploy workflow already had GHA layer caching configured

## Test plan
- [ ] Verify CI workflow runs successfully on this PR
- [ ] Confirm cache hit on subsequent CI runs (look for "cache restored" in setup-go logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)