### PR TITLE
[backflow] Log running task count every 30 seconds

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -17,6 +17,7 @@ import (
 // maxInspectFailures is the number of consecutive container inspect failures
 // before a task is killed or requeued.
 const maxInspectFailures = 3
+const runningTasksLogInterval = 30 * time.Second
 
 // Orchestrator manages the lifecycle of tasks: dispatching them to instances,
 // monitoring their containers, handling completions, and recovering from restarts.
@@ -160,7 +161,9 @@ func (o *Orchestrator) Start(ctx context.Context) {
 	o.recoverOnStartup(ctx)
 
 	ticker := time.NewTicker(o.config.PollInterval)
+	logTicker := time.NewTicker(runningTasksLogInterval)
 	defer ticker.Stop()
+	defer logTicker.Stop()
 
 	for {
 		select {
@@ -172,6 +175,8 @@ func (o *Orchestrator) Start(ctx context.Context) {
 			return
 		case <-ticker.C:
 			o.tick(ctx)
+		case <-logTicker.C:
+			o.logRunningTasks()
 		}
 	}
 }
@@ -206,6 +211,16 @@ func (o *Orchestrator) decrementRunning() {
 		o.running--
 	}
 	o.mu.Unlock()
+}
+
+func (o *Orchestrator) runningCount() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.running
+}
+
+func (o *Orchestrator) logRunningTasks() {
+	log.Info().Int("running_tasks", o.runningCount()).Msg("orchestrator: running task count")
 }
 
 // releaseInstanceSlot decrements the running container count for an instance.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,8 +1,13 @@
 package orchestrator
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"github.com/backflow-labs/backflow/internal/models"
 )
@@ -50,5 +55,28 @@ func TestInitFargateMode_DBError_DoesNotCreateInstance(t *testing.T) {
 	// On a real DB error, initFargateMode should bail out — not create an instance.
 	if _, exists := ms.instances["fargate"]; exists {
 		t.Fatal("expected no instance to be created when GetInstance returns a real DB error")
+	}
+}
+
+func TestLogRunningTasks_LogsCurrentCount(t *testing.T) {
+	ms := newMockStore()
+	o := newTestOrchestrator(ms, &mockNotifier{})
+	o.running = 3
+
+	var buf bytes.Buffer
+	prevLogger := log.Logger
+	log.Logger = zerolog.New(&buf)
+	defer func() {
+		log.Logger = prevLogger
+	}()
+
+	o.logRunningTasks()
+
+	output := buf.String()
+	if !strings.Contains(output, `"message":"orchestrator: running task count"`) {
+		t.Fatalf("log output = %q, want running task count message", output)
+	}
+	if !strings.Contains(output, `"running_tasks":3`) {
+		t.Fatalf("log output = %q, want running_tasks count", output)
 	}
 }


### PR DESCRIPTION
## Summary
- add a 30-second ticker in the orchestrator start loop
- log the current running task count with a dedicated helper
- add a unit test that verifies the structured log includes the expected message and count

## Why
- make it easier to observe orchestrator concurrency over time without waiting for task state transitions or inspecting internal state