### PR TITLE
Update documentation and create goose migration skill

### DIFF
--- a/.claude/skills/goose-migration.md
+++ b/.claude/skills/goose-migration.md
@@ -1,0 +1,23 @@
+---
+name: goose-migration
+description: Create and edit Backflow goose migrations in migrations/.
+---
+
+# Goose Migration Skill
+
+Use this when creating or updating a Backflow database migration.
+
+## Workflow
+
+1. Inspect `migrations/` and find the highest existing numeric prefix in `NNN_*.sql`.
+2. If the directory is empty, start with `001`.
+3. Ask what schema change is needed if it is not already specified.
+4. Create the next file as `NNN_slug.sql` with `-- +goose Up` and `-- +goose Down` sections.
+5. Keep the SQL Postgres-native and consistent with `migrations/001_initial_schema.sql`.
+6. Prefer `TEXT`, `INTEGER`, `BOOLEAN`, `DOUBLE PRECISION`, `JSONB`, and `TIMESTAMPTZ` over SQLite idioms.
+7. Make the migration reversible. Use `IF EXISTS` / `IF NOT EXISTS` where it helps safety.
+
+## Output shape
+
+- Only generate the new migration file unless the user asks for additional changes.
+- Keep index names consistent with existing conventions, such as `idx_<table>_<column>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@ make docker-build-local # Single-architecture build
 make docker-push        # Tag + push to ECR (requires REGISTRY=<ecr-uri>)
 make docker-deploy      # Full ECR pipeline: login, buildx, push
 make setup-aws          # Create AWS infrastructure
+goose -dir migrations status # Show pending/applied migrations
+goose -dir migrations up     # Apply the next migration(s)
+goose -dir migrations down   # Roll back the last migration
 ```
 
 Single test: `go test ./internal/store/ -run TestCreateTask -v`
@@ -27,7 +30,7 @@ Single test: `go test ./internal/store/ -run TestCreateTask -v`
 
 Two goroutines: chi REST API on `:8080` + polling orchestrator (5s default). Three operating modes: `ec2` (default, spot instances), `local` (Docker on local machine), and `fargate` (one ECS task per Backflow task, no instance management).
 
-**Flow:** Client → API → SQLite → Orchestrator → Docker on EC2 via SSM, local Docker, or ECS/Fargate → Webhooks.
+**Flow:** Client → API → PostgreSQL → Orchestrator → Docker on EC2 via SSM, local Docker, or ECS/Fargate → Webhooks.
 
 ### API endpoints (`/api/v1`)
 
@@ -42,7 +45,7 @@ Two goroutines: chi REST API on `:8080` + polling orchestrator (5s default). Thr
 
 - **api/** — chi router, handlers, JSON responses, `LogFetcher` interface
 - **orchestrator/** — Poll loop (`orchestrator.go`), EC2 scaling (`ec2.go`, `scaler.go`), Docker via SSM (`docker.go`), Fargate ECS/CloudWatch runner (`fargate.go`), spot interruption handling (`spot.go`), local mode (`local.go`)
-- **store/** — `Store` interface + SQLite (WAL mode, auto-migrated)
+- **store/** — `Store` interface + PostgreSQL (`pgxpool`, goose migrations)
 - **models/** — `Task` and `Instance` structs with status enums
 - **config/** — Env-var config (`BACKFLOW_*` prefix), three modes (`ec2`/`local`/`fargate`)
 - **notify/** — `Notifier` interface, `WebhookNotifier` (HTTP POST, 3 retries, event filtering), `NoopNotifier`
@@ -78,7 +81,7 @@ PR comments include actual cost for `claude_code` (extracted from `total_cost_us
 
 ## Fargate mode
 
-Set `BACKFLOW_MODE=fargate` to run each Backflow task as a standalone ECS task. Capacity is tracked through a synthetic `fargate` instance in SQLite; there are no EC2 instances to launch or drain.
+Set `BACKFLOW_MODE=fargate` to run each Backflow task as a standalone ECS task. Capacity is tracked through a synthetic `fargate` instance in PostgreSQL; there are no EC2 instances to launch or drain.
 
 Required env vars:
 
@@ -115,7 +118,17 @@ ECS prerequisites:
 
 ## Database
 
-PostgreSQL via Supabase (session pooler). Migrations managed by [goose](https://github.com/pressly/goose) and live in `migrations/`. The store implementation is in `internal/store/postgres.go` using `pgxpool`. Set `BACKFLOW_DATABASE_URL` to the Supabase session pooler connection string.
+PostgreSQL via Supabase (session pooler). Migrations are managed by [goose](https://github.com/pressly/goose) and live in `migrations/`. The store implementation is in `internal/store/postgres.go` using `pgxpool`. Set `BACKFLOW_DATABASE_URL` to the Supabase session pooler connection string.
+
+Migration workflow:
+
+```bash
+goose -dir migrations status
+goose -dir migrations up
+goose -dir migrations down
+```
+
+Create new migrations in `migrations/` with the next numeric prefix, `-- +goose Up`, and `-- +goose Down`.
 
 ## Documentation
 

--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -14,6 +14,13 @@ Complete mapping of every file in the Backflow repository.
 | `go.mod` | Go module definition (`github.com/backflow-labs/backflow`, Go 1.24.1) with dependencies |
 | `go.sum` | Go module checksums |
 
+## `.claude/`
+
+| File | Description |
+|------|-------------|
+| `settings.local.json` | Local Claude/Codex permission overrides for this workspace |
+| `skills/goose-migration.md` | Project skill for generating new goose migration files |
+
 ## `cmd/backflow/`
 
 Entry point for the server binary.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -115,4 +115,11 @@ pending → running → draining → terminated
 - All timestamps use `TIMESTAMPTZ` and default to `now()`. Nullable timestamps (`started_at`, `completed_at`) are NULL until set.
 - Booleans use native PostgreSQL `BOOLEAN` type.
 - JSON fields (`allowed_tools`, `env_vars`) use `JSONB` for indexed/queryable storage.
-- Schema migrations are managed by goose in `migrations/`. Run `goose up` to apply, `goose down` to rollback.
+- Schema migrations are managed by goose in `migrations/`.
+
+## Migration Workflow
+
+1. Inspect `migrations/` and determine the next numeric prefix.
+2. Create `NNN_slug.sql` with `-- +goose Up` and `-- +goose Down` sections.
+3. Use Postgres-native types that match the existing schema (`TIMESTAMPTZ`, `BOOLEAN`, `JSONB`, `DOUBLE PRECISION`, `TEXT`, `INTEGER`).
+4. Apply with `goose -dir migrations up`, inspect with `goose -dir migrations status`, and roll back with `goose -dir migrations down`.

--- a/docs/sms-setup.md
+++ b/docs/sms-setup.md
@@ -25,16 +25,16 @@ If `BACKFLOW_SMS_PROVIDER` is unset or empty, SMS is fully disabled (noop).
 
 ## 3. Register Allowed Senders
 
-Inbound SMS (creating tasks via text) requires pre-authorized senders in the `allowed_senders` table. Insert rows directly in SQLite:
+Inbound SMS (creating tasks via text) requires pre-authorized senders in the `allowed_senders` table. Insert rows directly in Postgres:
 
 ```sql
 INSERT INTO allowed_senders (channel_type, address, default_repo, enabled, created_at)
-VALUES ('sms', '+15559876543', 'https://github.com/org/repo', 1, datetime('now'));
+VALUES ('sms', '+15559876543', 'https://github.com/org/repo', true, now());
 ```
 
 - `address` — the sender's phone number in E.164 format
 - `default_repo` — optional; used when the SMS body doesn't include a repo URL
-- `enabled` — set to `0` to revoke access without deleting
+- `enabled` — set to `false` to revoke access without deleting
 
 ## 4. Configure Twilio Inbound Webhook
 


### PR DESCRIPTION
Implements #81.

Updates the Postgres migration docs in CLAUDE.md and docs/schema.md, refreshes the file reference, fixes the lingering SQLite example in docs/sms-setup.md, and adds the .claude/skills/goose-migration.md project skill for generating future goose migrations.