### PR TITLE
[backflow] Fix EventBus Emit-after-Close panic and deduplicate redactChannel

### DIFF
--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -79,6 +79,16 @@ type Task struct {
 	CompletedAt     *time.Time        `json:"completed_at,omitempty"`
 }
 
+// RedactChannel strips the value after ":" from a channel string,
+// keeping only the channel type (e.g. "sms:+15551234567" → "sms").
+// Returns the input unchanged if there is no ":" separator.
+func RedactChannel(ch string) string {
+	if idx := strings.Index(ch, ":"); idx >= 0 {
+		return ch[:idx]
+	}
+	return ch
+}
+
 // RedactReplyChannel replaces the full reply channel (e.g. "sms:+15551234567")
 // with just the channel type (e.g. "sms") to avoid exposing phone numbers in
 // API responses.
@@ -86,9 +96,7 @@ func (t *Task) RedactReplyChannel() {
 	if t.ReplyChannel == "" {
 		return
 	}
-	if idx := strings.Index(t.ReplyChannel, ":"); idx >= 0 {
-		t.ReplyChannel = t.ReplyChannel[:idx]
-	}
+	t.ReplyChannel = RedactChannel(t.ReplyChannel)
 }
 
 // AllowedToolsJSON returns the JSON representation for DB storage.

--- a/internal/notify/bus.go
+++ b/internal/notify/bus.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/rs/zerolog/log"
 )
@@ -15,6 +16,7 @@ type EventBus struct {
 	mu          sync.RWMutex
 	done        chan struct{}
 	closeOnce   sync.Once
+	closed      atomic.Bool
 }
 
 // NewEventBus creates and starts an EventBus with a buffered channel.
@@ -34,9 +36,16 @@ func (b *EventBus) Subscribe(n Notifier) {
 	b.subscribers = append(b.subscribers, n)
 }
 
-// Emit publishes an event to the bus. If the buffer is full, the event is
-// dropped with a warning. Emit never blocks the caller.
+// Emit publishes an event to the bus. If the buffer is full or the bus is
+// closed, the event is dropped with a warning. Emit never blocks the caller.
 func (b *EventBus) Emit(event Event) {
+	if b.closed.Load() {
+		log.Warn().
+			Str("event", string(event.Type)).
+			Str("task_id", event.TaskID).
+			Msg("event bus closed, dropping event")
+		return
+	}
 	select {
 	case b.ch <- event:
 	default:
@@ -50,6 +59,7 @@ func (b *EventBus) Emit(event Event) {
 // Close stops the bus and waits for all pending events to be delivered.
 func (b *EventBus) Close() {
 	b.closeOnce.Do(func() {
+		b.closed.Store(true)
 		close(b.ch)
 		<-b.done
 	})

--- a/internal/notify/bus_test.go
+++ b/internal/notify/bus_test.go
@@ -240,6 +240,25 @@ func TestEventBus_GracefulShutdown(t *testing.T) {
 	}
 }
 
+func TestEventBus_EmitAfterClose(t *testing.T) {
+	bus := NewEventBus()
+	bus.Close()
+
+	// Emit after Close must not panic.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		bus.Emit(Event{Type: EventTaskRunning, TaskID: "bf_late", Timestamp: time.Now()})
+	}()
+
+	select {
+	case <-done:
+		// good — no panic
+	case <-time.After(time.Second):
+		t.Fatal("Emit after Close blocked")
+	}
+}
+
 func TestEventBus_NoSubscribers(t *testing.T) {
 	bus := NewEventBus()
 

--- a/internal/notify/event.go
+++ b/internal/notify/event.go
@@ -1,7 +1,6 @@
 package notify
 
 import (
-	"strings"
 	"time"
 
 	"github.com/backflow-labs/backflow/internal/models"
@@ -26,7 +25,7 @@ func NewEvent(eventType EventType, task *models.Task, opts ...EventOption) Event
 		TaskID:       task.ID,
 		RepoURL:      task.RepoURL,
 		Prompt:       task.Prompt,
-		ReplyChannel: redactChannel(task.ReplyChannel),
+		ReplyChannel: models.RedactChannel(task.ReplyChannel),
 		Timestamp:    time.Now().UTC(),
 	}
 	for _, opt := range opts {
@@ -35,11 +34,3 @@ func NewEvent(eventType EventType, task *models.Task, opts ...EventOption) Event
 	return e
 }
 
-// redactChannel strips the value after ":" from a reply channel,
-// keeping only the channel type (e.g. "sms:+15551234567" → "sms").
-func redactChannel(ch string) string {
-	if idx := strings.Index(ch, ":"); idx >= 0 {
-		return ch[:idx]
-	}
-	return ch
-}


### PR DESCRIPTION
## Summary

Review fixes for PR #100 — addresses a correctness bug and a code duplication issue found during review.

- **Fix Emit-after-Close panic:** `EventBus.Emit()` would panic with "send on closed channel" if called after `Close()`. Added an `atomic.Bool` guard so late emissions are safely dropped with a warning instead of crashing.
- **Deduplicate redactChannel:** Extracted `models.RedactChannel()` as a shared helper, replacing the duplicate implementation in `notify/event.go` and reusing it in `Task.RedactReplyChannel()`.
- **Add test coverage:** `TestEventBus_EmitAfterClose` verifies the fix — Emit after Close completes without panic.

See [PR #100 review](https://github.com/backflow-labs/backflow/pull/100#pullrequestreview-3972405132) for the full code review with inline comments.

## Test plan

- [x] `TestEventBus_EmitAfterClose` — Emit after Close does not panic or block
- [x] All existing EventBus tests pass (fan-out, isolation, async, graceful shutdown, no-subscribers)
- [x] All existing NewEvent tests pass (field population, all event types, WithContainerStatus)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)