### PR TITLE
[backflow] Add Slack webhook notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,8 +57,12 @@ BACKFLOW_DEFAULT_MAX_RUNTIME_MIN=30
 BACKFLOW_DEFAULT_MAX_TURNS=200
 
 # Webhooks (optional)
-# BACKFLOW_WEBHOOK_URL=https://hooks.slack.com/services/...
+# BACKFLOW_WEBHOOK_URL=https://example.com/webhook
 # BACKFLOW_WEBHOOK_EVENTS=task.needs_input,task.failed,task.completed
+
+# Slack notifications (optional)
+# BACKFLOW_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+# BACKFLOW_SLACK_EVENTS=task.needs_input,task.failed,task.completed
 
 # SMS / Messaging (optional — disabled when BACKFLOW_SMS_PROVIDER is unset)
 # BACKFLOW_SMS_PROVIDER=twilio

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,12 +88,12 @@ Optional env vars:
 
 At startup, Backflow persists the install config to the `discord_installs` table, registers the `/backflow` slash command via the Discord API, mounts the interaction handler at `/webhooks/discord`, and subscribes a `DiscordNotifier` stub to the event bus. Actual Discord message delivery will be implemented in a future issue.
 
-### Slack notification stub
+### Slack notifications
 
 - `BACKFLOW_SLACK_WEBHOOK_URL`
 - `BACKFLOW_SLACK_EVENTS` (comma-separated event filter)
 
-If the Slack webhook URL is set, `cmd/backflow/main.go` logs that the subscriber is not yet implemented.
+If the Slack webhook URL is set, `cmd/backflow/main.go` subscribes the Slack notifier and posts task lifecycle updates to the webhook.
 
 ## Harnesses
 

--- a/cmd/backflow/main.go
+++ b/cmd/backflow/main.go
@@ -65,6 +65,9 @@ func main() {
 		bus.Subscribe(notify.NewWebhookNotifier(cfg.WebhookURL, cfg.WebhookEvents))
 		log.Info().Str("url", cfg.WebhookURL).Msg("webhook notifications enabled")
 	}
+	if cfg.SlackWebhookURL != "" {
+		bus.Subscribe(notify.NewSlackNotifier(cfg.SlackWebhookURL, cfg.SlackEvents))
+	}
 	logConfiguredNotificationChannels(cfg)
 
 	// Initialize messaging
@@ -193,6 +196,6 @@ func main() {
 
 func logConfiguredNotificationChannels(cfg *config.Config) {
 	if cfg.SlackWebhookURL != "" {
-		log.Info().Msg("slack notifications configured but subscriber not yet implemented")
+		log.Info().Msg("slack notifications enabled")
 	}
 }

--- a/cmd/backflow/main_test.go
+++ b/cmd/backflow/main_test.go
@@ -26,8 +26,8 @@ func TestLogConfiguredNotificationChannels(t *testing.T) {
 	logConfiguredNotificationChannels(cfg)
 
 	out := buf.String()
-	if !strings.Contains(out, "slack notifications configured but subscriber not yet implemented") {
-		t.Fatalf("log output missing Slack placeholder message: %s", out)
+	if !strings.Contains(out, "slack notifications enabled") {
+		t.Fatalf("log output missing Slack enabled message: %s", out)
 	}
 	if strings.Contains(out, cfg.SlackWebhookURL) {
 		t.Fatalf("log output leaked Slack URL: %s", out)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,7 +87,7 @@ type Config struct {
 	SMSFromNumber    string
 	SMSEvents        []string
 
-	// Slack (subscriber implementation is out of scope)
+	// Slack notifications
 	SlackWebhookURL string
 	SlackEvents     []string
 

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -1,0 +1,89 @@
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type SlackNotifier struct {
+	url        string
+	events     map[EventType]bool
+	httpClient *http.Client
+}
+
+func NewSlackNotifier(url string, filterEvents []string) *SlackNotifier {
+	s := &SlackNotifier{
+		url: url,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+	if len(filterEvents) > 0 {
+		s.events = make(map[EventType]bool, len(filterEvents))
+		for _, e := range filterEvents {
+			s.events[EventType(e)] = true
+		}
+	}
+	return s
+}
+
+func (s *SlackNotifier) Notify(event Event) error {
+	if s.events != nil && !s.events[event.Type] {
+		return nil
+	}
+
+	body, err := json.Marshal(struct {
+		Text string `json:"text"`
+	}{
+		Text: formatSlackMessage(event),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal slack payload: %w", err)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * 2 * time.Second)
+		}
+
+		req, err := http.NewRequest(http.MethodPost, s.url, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "backflow-slack/1.0")
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			log.Warn().Err(err).Int("attempt", attempt+1).Str("event", string(event.Type)).Msg("slack request failed")
+			continue
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			log.Debug().Str("event", string(event.Type)).Str("task_id", event.TaskID).Msg("slack webhook sent")
+			return nil
+		}
+		lastErr = fmt.Errorf("slack webhook returned status %d", resp.StatusCode)
+		log.Warn().Int("status", resp.StatusCode).Int("attempt", attempt+1).Msg("slack webhook non-2xx response")
+	}
+
+	return fmt.Errorf("slack webhook failed after 3 attempts: %w", lastErr)
+}
+
+func (s *SlackNotifier) Name() string { return "slack" }
+
+func formatSlackMessage(event Event) string {
+	msg := formatEventMessage(event)
+	if event.RepoURL == "" {
+		return fmt.Sprintf("*Backflow*\n%s", msg)
+	}
+	return fmt.Sprintf("*Backflow*\n%s\nRepo: %s", msg, event.RepoURL)
+}

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -1,0 +1,95 @@
+package notify
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSlackNotifier_NotifySendsTextPayload(t *testing.T) {
+	var gotBody string
+	var gotErr error
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			gotErr = err
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		gotBody = string(raw)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	notifier := NewSlackNotifier(server.URL, nil)
+	event := Event{
+		Type:      EventTaskCompleted,
+		TaskID:    "bf_123",
+		PRURL:     "https://github.com/org/repo/pull/42",
+		RepoURL:   "https://github.com/org/repo",
+		Timestamp: time.Now().UTC(),
+	}
+
+	if err := notifier.Notify(event); err != nil {
+		t.Fatalf("Notify() error = %v", err)
+	}
+	if gotErr != nil {
+		t.Fatalf("read request body: %v", gotErr)
+	}
+
+	var payload struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.Text == "" {
+		t.Fatal("expected slack payload text")
+	}
+	if !strings.Contains(payload.Text, "bf_123") {
+		t.Fatalf("payload text %q does not mention task id", payload.Text)
+	}
+	if !strings.Contains(payload.Text, "completed") {
+		t.Fatalf("payload text %q does not mention completion", payload.Text)
+	}
+	if !strings.Contains(payload.Text, "Repo: https://github.com/org/repo") {
+		t.Fatalf("payload text %q does not include repo url", payload.Text)
+	}
+}
+
+func TestSlackNotifier_EventFilter(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	notifier := NewSlackNotifier(server.URL, []string{"task.failed"})
+
+	if err := notifier.Notify(Event{Type: EventTaskCompleted, TaskID: "bf_123", Timestamp: time.Now().UTC()}); err != nil {
+		t.Fatalf("Notify(completed) error = %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected no request for filtered event, got %d", calls)
+	}
+
+	if err := notifier.Notify(Event{Type: EventTaskFailed, TaskID: "bf_123", Timestamp: time.Now().UTC()}); err != nil {
+		t.Fatalf("Notify(failed) error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected one request for matching event, got %d", calls)
+	}
+}
+
+func TestSlackNotifier_Name(t *testing.T) {
+	if got := NewSlackNotifier("https://hooks.slack.com/services/test", nil).Name(); got != "slack" {
+		t.Fatalf("Name() = %q, want %q", got, "slack")
+	}
+}


### PR DESCRIPTION
Adds a real Slack webhook notifier so `BACKFLOW_SLACK_WEBHOOK_URL` now delivers task lifecycle events instead of only logging a placeholder. The notifier supports event filtering, posts a compact Slack text payload, and is wired into startup alongside the existing notification channels. Also updates the config example, project context, and tests.