### PR TITLE
[backflow] Add Discord code-task creation modal flow

### DIFF
--- a/cmd/backflow/main.go
+++ b/cmd/backflow/main.go
@@ -124,7 +124,11 @@ func main() {
 		if err != nil {
 			log.Fatal().Err(err).Msg("invalid BACKFLOW_DISCORD_PUBLIC_KEY")
 		}
-		router.Post("/webhooks/discord", discord.InteractionHandler(pubKey, db))
+		router.Post("/webhooks/discord", discord.InteractionHandler(pubKey, db, cfg, func(task *models.Task) {
+			if bus != nil {
+				bus.Emit(notify.NewEvent(notify.EventTaskCreated, task))
+			}
+		}))
 
 		now := time.Now().UTC()
 		install := &models.DiscordInstall{

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/oklog/ulid/v2"
 
 	"github.com/backflow-labs/backflow/internal/config"
 	"github.com/backflow-labs/backflow/internal/models"
 	"github.com/backflow-labs/backflow/internal/notify"
 	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/backflow-labs/backflow/internal/taskbuilder"
 )
 
 // LogFetcher retrieves container logs for a running task.
@@ -44,44 +44,7 @@ func (h *Handlers) CreateTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	now := time.Now().UTC()
-	taskMode := withDefault(req.TaskMode, models.TaskModeCode)
-	harness := models.Harness(withDefault(req.Harness, h.config.DefaultHarness))
-
-	// Pick harness-specific default model
-	defaultModel := h.config.DefaultClaudeModel
-	if harness == models.HarnessCodex {
-		defaultModel = h.config.DefaultCodexModel
-	}
-
-	task := &models.Task{
-		ID:              "bf_" + ulid.Make().String(),
-		Status:          models.TaskStatusPending,
-		TaskMode:        taskMode,
-		Harness:         harness,
-		RepoURL:         req.RepoURL,
-		Branch:          req.Branch,
-		TargetBranch:    req.TargetBranch,
-		ReviewPRURL:     req.ReviewPRURL,
-		ReviewPRNumber:  req.ReviewPRNumber,
-		Prompt:          req.Prompt,
-		Context:         req.Context,
-		Model:           withDefault(req.Model, defaultModel),
-		Effort:          withDefault(req.Effort, h.config.DefaultEffort),
-		MaxBudgetUSD:    withDefaultFloat(req.MaxBudgetUSD, h.config.DefaultMaxBudget),
-		MaxRuntimeMin:   withDefaultInt(req.MaxRuntimeMin, int(h.config.DefaultMaxRuntime.Minutes())),
-		MaxTurns:        withDefaultInt(req.MaxTurns, h.config.DefaultMaxTurns),
-		CreatePR:        req.CreatePR,
-		SelfReview:      req.SelfReview,
-		SaveAgentOutput: req.SaveAgentOutput == nil || *req.SaveAgentOutput,
-		PRTitle:         req.PRTitle,
-		PRBody:          req.PRBody,
-		AllowedTools:    req.AllowedTools,
-		ClaudeMD:        req.ClaudeMD,
-		EnvVars:         req.EnvVars,
-		CreatedAt:       now,
-		UpdatedAt:       now,
-	}
+	task := taskbuilder.Build(h.config, req, time.Now().UTC())
 
 	if err := h.store.CreateTask(r.Context(), task); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create task")
@@ -220,25 +183,4 @@ func (h *Handlers) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		"status":    "ok",
 		"auth_mode": string(h.config.AuthMode),
 	})
-}
-
-func withDefault(val, fallback string) string {
-	if val == "" {
-		return fallback
-	}
-	return val
-}
-
-func withDefaultFloat(val, fallback float64) float64 {
-	if val == 0 {
-		return fallback
-	}
-	return val
-}
-
-func withDefaultInt(val, fallback int) int {
-	if val == 0 {
-		return fallback
-	}
-	return val
 }

--- a/internal/discord/commands.go
+++ b/internal/discord/commands.go
@@ -42,9 +42,14 @@ func RegisterCommands(baseURL, appID, botToken string) error {
 	commands := []slashCommand{
 		{
 			Name:        "backflow",
-			Description: "Inspect Backflow tasks",
+			Description: "Create and inspect Backflow tasks",
 			Type:        1, // CHAT_INPUT
 			Options: []slashCommandOption{
+				{
+					Name:        "create",
+					Description: "Create a code task",
+					Type:        1, // SUB_COMMAND
+				},
 				{
 					Name:        "status",
 					Description: "Look up a task by ID",

--- a/internal/discord/interactions.go
+++ b/internal/discord/interactions.go
@@ -9,13 +9,16 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/backflow-labs/backflow/internal/config"
 	"github.com/backflow-labs/backflow/internal/models"
 	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/backflow-labs/backflow/internal/taskbuilder"
 )
 
 // Discord interaction types.
@@ -31,7 +34,10 @@ const (
 	ResponseTypePong                   = 1
 	ResponseTypeChannelMessage         = 4
 	ResponseTypeDeferredChannelMessage = 5
+	ResponseTypeModal                  = 9
 )
+
+const discordFlagEphemeral = 1 << 6
 
 // Interaction is the minimal Discord interaction payload needed for routing.
 type Interaction struct {
@@ -67,16 +73,63 @@ type ChannelMessageResponse struct {
 // MessageData is the content payload inside a channel message response.
 type MessageData struct {
 	Content string `json:"content"`
+	Flags   int    `json:"flags,omitempty"`
+}
+
+// ModalResponse opens a Discord modal.
+type ModalResponse struct {
+	Type int       `json:"type"`
+	Data ModalData `json:"data"`
+}
+
+// ModalData is the modal payload returned to Discord.
+type ModalData struct {
+	CustomID   string           `json:"custom_id"`
+	Title      string           `json:"title"`
+	Components []ModalActionRow `json:"components"`
+}
+
+// ModalActionRow contains a single text input for Discord modals.
+type ModalActionRow struct {
+	Type       int              `json:"type"`
+	Components []ModalTextInput `json:"components"`
+}
+
+// ModalTextInput is the subset of Discord text input configuration used here.
+type ModalTextInput struct {
+	Type        int    `json:"type"`
+	CustomID    string `json:"custom_id"`
+	Label       string `json:"label"`
+	Style       int    `json:"style"`
+	Required    bool   `json:"required,omitempty"`
+	Placeholder string `json:"placeholder,omitempty"`
+	Value       string `json:"value,omitempty"`
+	MaxLength   int    `json:"max_length,omitempty"`
+}
+
+type modalSubmitData struct {
+	CustomID   string                 `json:"custom_id"`
+	Components []modalSubmitComponent `json:"components"`
+}
+
+type modalSubmitComponent struct {
+	Components []modalSubmitValue `json:"components"`
+}
+
+type modalSubmitValue struct {
+	CustomID string `json:"custom_id"`
+	Value    string `json:"value"`
 }
 
 type discordTaskStore interface {
+	CreateTask(ctx context.Context, task *models.Task) error
 	GetTask(ctx context.Context, id string) (*models.Task, error)
 	ListTasks(ctx context.Context, filter store.TaskFilter) ([]*models.Task, error)
 }
 
 // InteractionHandler returns an http.HandlerFunc that verifies and routes
 // Discord interaction webhook requests.
-func InteractionHandler(publicKey ed25519.PublicKey, taskStore discordTaskStore) http.HandlerFunc {
+func InteractionHandler(publicKey ed25519.PublicKey, taskStore discordTaskStore, cfg *config.Config, onTaskCreated func(*models.Task)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		signature := r.Header.Get("X-Signature-Ed25519")
 		timestamp := r.Header.Get("X-Signature-Timestamp")
@@ -112,8 +165,10 @@ func InteractionHandler(publicKey ed25519.PublicKey, taskStore discordTaskStore)
 			log.Info().Msg("discord: PING received, responding with PONG")
 			respondJSON(w, InteractionResponse{Type: ResponseTypePong})
 		case InteractionTypeApplicationCommand:
-			handleApplicationCommand(r.Context(), w, interaction, taskStore)
-		case InteractionTypeMessageComponent, InteractionTypeModalSubmit:
+			handleApplicationCommand(r.Context(), w, interaction, taskStore, cfg)
+		case InteractionTypeModalSubmit:
+			handleModalSubmit(r.Context(), w, interaction, taskStore, cfg, onTaskCreated)
+		case InteractionTypeMessageComponent:
 			log.Info().Int("type", interaction.Type).Msg("discord: interaction received (stub)")
 			respondJSON(w, InteractionResponse{Type: ResponseTypeDeferredChannelMessage})
 		default:
@@ -123,7 +178,7 @@ func InteractionHandler(publicKey ed25519.PublicKey, taskStore discordTaskStore)
 	}
 }
 
-func handleApplicationCommand(ctx context.Context, w http.ResponseWriter, interaction Interaction, taskStore discordTaskStore) {
+func handleApplicationCommand(ctx context.Context, w http.ResponseWriter, interaction Interaction, taskStore discordTaskStore, cfg *config.Config) {
 	var cmd CommandData
 	if err := json.Unmarshal(interaction.Data, &cmd); err != nil {
 		log.Warn().Err(err).Msg("discord: failed to parse command data")
@@ -145,12 +200,18 @@ func handleApplicationCommand(ctx context.Context, w http.ResponseWriter, intera
 	if !ok {
 		respondJSON(w, ChannelMessageResponse{
 			Type: ResponseTypeChannelMessage,
-			Data: MessageData{Content: "Use /backflow status or /backflow list."},
+			Data: MessageData{Content: "Use /backflow create, /backflow status, or /backflow list."},
 		})
 		return
 	}
 
 	switch subcommand {
+	case "create":
+		if cfg == nil || taskStore == nil {
+			respondJSON(w, ephemeralMessage("Task creation is unavailable right now."))
+			return
+		}
+		respondJSON(w, newCreateTaskModal())
 	case "status":
 		taskID, err := stringOption(options, "task_id")
 		if err != nil {
@@ -231,6 +292,44 @@ func handleApplicationCommand(ctx context.Context, w http.ResponseWriter, intera
 	}
 }
 
+func handleModalSubmit(ctx context.Context, w http.ResponseWriter, interaction Interaction, taskStore discordTaskStore, cfg *config.Config, onTaskCreated func(*models.Task)) {
+	var data modalSubmitData
+	if err := json.Unmarshal(interaction.Data, &data); err != nil {
+		log.Warn().Err(err).Msg("discord: failed to parse modal submit data")
+		http.Error(w, "invalid modal submit data", http.StatusBadRequest)
+		return
+	}
+
+	switch data.CustomID {
+	case discordCreateTaskModalID:
+		if cfg == nil || taskStore == nil {
+			respondJSON(w, ephemeralMessage("Task creation is unavailable right now."))
+			return
+		}
+		req, err := createTaskRequestFromModal(data)
+		if err != nil {
+			respondJSON(w, ephemeralMessage(err.Error()))
+			return
+		}
+		if err := req.Validate(); err != nil {
+			respondJSON(w, ephemeralMessage(err.Error()))
+			return
+		}
+		task := taskbuilder.Build(cfg, req, time.Now().UTC())
+		if err := taskStore.CreateTask(ctx, task); err != nil {
+			log.Warn().Err(err).Msg("discord: failed to create task from modal")
+			respondJSON(w, ephemeralMessage("Failed to create task."))
+			return
+		}
+		if onTaskCreated != nil {
+			onTaskCreated(task)
+		}
+		respondJSON(w, ephemeralMessage(formatTaskCreated(task)))
+	default:
+		respondJSON(w, ephemeralMessage("Unknown modal submission."))
+	}
+}
+
 func (c CommandData) firstSubcommand() (string, []CommandOption, bool) {
 	for _, opt := range c.Options {
 		if opt.Type == 1 {
@@ -272,7 +371,142 @@ const (
 	defaultDiscordTaskListLimit = 5
 	maxDiscordTaskListLimit     = 10
 	maxDiscordMessageLength     = 1900
+	discordCreateTaskModalID    = "backflow:create:code"
+	discordRepoURLFieldID       = "repo_url"
+	discordPromptFieldID        = "prompt"
+	discordBranchFieldID        = "branch"
+	discordTargetBranchFieldID  = "target_branch"
+	discordAdvancedFieldID      = "advanced"
 )
+
+func newCreateTaskModal() ModalResponse {
+	return ModalResponse{
+		Type: ResponseTypeModal,
+		Data: ModalData{
+			CustomID: discordCreateTaskModalID,
+			Title:    "Create Code Task",
+			Components: []ModalActionRow{
+				newTextInputRow(discordRepoURLFieldID, "Repository URL", 1, true, "https://github.com/owner/repo", 200),
+				newTextInputRow(discordPromptFieldID, "Prompt", 2, true, "Describe the code task", 4000),
+				newTextInputRow(discordBranchFieldID, "Branch (optional)", 1, false, "feature/my-branch", 200),
+				newTextInputRow(discordTargetBranchFieldID, "Target Branch (optional)", 1, false, "main", 200),
+				newTextInputRow(discordAdvancedFieldID, "Advanced (optional)", 2, false, "harness=codex\nbudget=10\nruntime=30", 300),
+			},
+		},
+	}
+}
+
+func newTextInputRow(customID, label string, style int, required bool, placeholder string, maxLength int) ModalActionRow {
+	return ModalActionRow{
+		Type: 1,
+		Components: []ModalTextInput{
+			{
+				Type:        4,
+				CustomID:    customID,
+				Label:       label,
+				Style:       style,
+				Required:    required,
+				Placeholder: placeholder,
+				MaxLength:   maxLength,
+			},
+		},
+	}
+}
+
+func ephemeralMessage(content string) ChannelMessageResponse {
+	return ChannelMessageResponse{
+		Type: ResponseTypeChannelMessage,
+		Data: MessageData{
+			Content: truncate(content, maxDiscordMessageLength),
+			Flags:   discordFlagEphemeral,
+		},
+	}
+}
+
+func createTaskRequestFromModal(data modalSubmitData) (models.CreateTaskRequest, error) {
+	values := modalValues(data)
+	req := models.CreateTaskRequest{
+		TaskMode:     models.TaskModeCode,
+		RepoURL:      strings.TrimSpace(values[discordRepoURLFieldID]),
+		Prompt:       strings.TrimSpace(values[discordPromptFieldID]),
+		Branch:       strings.TrimSpace(values[discordBranchFieldID]),
+		TargetBranch: strings.TrimSpace(values[discordTargetBranchFieldID]),
+		CreatePR:     true,
+	}
+
+	if err := applyAdvancedTaskOptions(&req, values[discordAdvancedFieldID]); err != nil {
+		return models.CreateTaskRequest{}, err
+	}
+	return req, nil
+}
+
+func modalValues(data modalSubmitData) map[string]string {
+	values := make(map[string]string)
+	for _, row := range data.Components {
+		for _, component := range row.Components {
+			values[component.CustomID] = component.Value
+		}
+	}
+	return values
+}
+
+func applyAdvancedTaskOptions(req *models.CreateTaskRequest, raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return fmt.Errorf("advanced options must use key=value lines")
+		}
+		key = strings.ToLower(strings.TrimSpace(key))
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return fmt.Errorf("advanced option %s requires a value", key)
+		}
+
+		switch key {
+		case "harness":
+			req.Harness = value
+		case "budget":
+			budget, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return fmt.Errorf("budget must be a number")
+			}
+			req.MaxBudgetUSD = budget
+		case "runtime":
+			runtime, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("runtime must be an integer number of minutes")
+			}
+			req.MaxRuntimeMin = runtime
+		default:
+			return fmt.Errorf("unsupported advanced option: %s", key)
+		}
+	}
+
+	return nil
+}
+
+func formatTaskCreated(task *models.Task) string {
+	parts := []string{
+		fmt.Sprintf("Created task %s.", task.ID),
+		task.RepoURL,
+	}
+	if task.Branch != "" {
+		parts = append(parts, "branch "+task.Branch)
+	}
+	if task.TargetBranch != "" {
+		parts = append(parts, "target "+task.TargetBranch)
+	}
+	parts = append(parts, "Follow updates in the task thread.")
+	return strings.Join(parts, " | ")
+}
 
 func formatTaskStatus(task *models.Task) string {
 	parts := []string{

--- a/internal/discord/interactions_test.go
+++ b/internal/discord/interactions_test.go
@@ -12,13 +12,28 @@ import (
 	"testing"
 	"time"
 
+	"github.com/backflow-labs/backflow/internal/config"
 	"github.com/backflow-labs/backflow/internal/models"
 	"github.com/backflow-labs/backflow/internal/store"
 )
 
 type fakeTaskStore struct {
-	tasks map[string]*models.Task
-	list  []*models.Task
+	tasks     map[string]*models.Task
+	list      []*models.Task
+	created   []*models.Task
+	createErr error
+}
+
+func (f *fakeTaskStore) CreateTask(ctx context.Context, task *models.Task) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	if f.tasks == nil {
+		f.tasks = make(map[string]*models.Task)
+	}
+	f.tasks[task.ID] = task
+	f.created = append(f.created, task)
+	return nil
 }
 
 func (f *fakeTaskStore) GetTask(ctx context.Context, id string) (*models.Task, error) {
@@ -45,6 +60,14 @@ func (f *fakeTaskStore) ListTasks(ctx context.Context, filter store.TaskFilter) 
 		end = start + filter.Limit
 	}
 	return out[start:end], nil
+}
+
+type taskCreatedRecorder struct {
+	tasks []*models.Task
+}
+
+func (r *taskCreatedRecorder) record(task *models.Task) {
+	r.tasks = append(r.tasks, task)
 }
 
 func testKeyPair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
@@ -78,7 +101,7 @@ func postInteraction(handler http.HandlerFunc, priv ed25519.PrivateKey, body str
 
 func TestInteractionHandler_Ping(t *testing.T) {
 	pub, priv := testKeyPair(t)
-	handler := InteractionHandler(pub, nil)
+	handler := InteractionHandler(pub, nil, nil, nil)
 
 	rr := postInteraction(handler, priv, `{"type":1}`)
 
@@ -96,7 +119,7 @@ func TestInteractionHandler_Ping(t *testing.T) {
 
 func TestInteractionHandler_InvalidSignature(t *testing.T) {
 	pub, _ := testKeyPair(t)
-	handler := InteractionHandler(pub, nil)
+	handler := InteractionHandler(pub, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/discord", strings.NewReader(`{"type":1}`))
 	req.Header.Set("X-Signature-Ed25519", "deadbeef")
@@ -112,7 +135,7 @@ func TestInteractionHandler_InvalidSignature(t *testing.T) {
 
 func TestInteractionHandler_MissingHeaders(t *testing.T) {
 	pub, _ := testKeyPair(t)
-	handler := InteractionHandler(pub, nil)
+	handler := InteractionHandler(pub, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/webhooks/discord", strings.NewReader(`{"type":1}`))
 	// No signature headers
@@ -127,7 +150,7 @@ func TestInteractionHandler_MissingHeaders(t *testing.T) {
 
 func TestInteractionHandler_BackflowRootCommand(t *testing.T) {
 	pub, priv := testKeyPair(t)
-	handler := InteractionHandler(pub, nil)
+	handler := InteractionHandler(pub, nil, nil, nil)
 
 	rr := postInteraction(handler, priv, `{"type":2,"data":{"name":"backflow"}}`)
 
@@ -141,7 +164,7 @@ func TestInteractionHandler_BackflowRootCommand(t *testing.T) {
 	if resp.Type != ResponseTypeChannelMessage {
 		t.Errorf("response type = %d, want %d", resp.Type, ResponseTypeChannelMessage)
 	}
-	if !strings.Contains(resp.Data.Content, "Use /backflow status or /backflow list") {
+	if !strings.Contains(resp.Data.Content, "Use /backflow create, /backflow status, or /backflow list") {
 		t.Errorf("content = %q, want usage guidance", resp.Data.Content)
 	}
 }
@@ -161,7 +184,7 @@ func TestInteractionHandler_BackflowStatusCommand(t *testing.T) {
 			},
 		},
 	}
-	handler := InteractionHandler(pub, store)
+	handler := InteractionHandler(pub, store, nil, nil)
 
 	body := `{"type":2,"data":{"name":"backflow","options":[{"name":"status","type":1,"options":[{"name":"task_id","type":3,"value":"bf_123"}]}]}}`
 	rr := postInteraction(handler, priv, body)
@@ -191,7 +214,7 @@ func TestInteractionHandler_BackflowListCommand(t *testing.T) {
 			{ID: "bf_3", Status: models.TaskStatusCompleted, RepoURL: "https://github.com/test/repo3", CreatedAt: now, UpdatedAt: now},
 		},
 	}
-	handler := InteractionHandler(pub, store)
+	handler := InteractionHandler(pub, store, nil, nil)
 
 	body := `{"type":2,"data":{"name":"backflow","options":[{"name":"list","type":1,"options":[{"name":"status","type":3,"value":"running"},{"name":"limit","type":4,"value":2},{"name":"offset","type":4,"value":0}]}]}}`
 	rr := postInteraction(handler, priv, body)
@@ -220,7 +243,7 @@ func TestInteractionHandler_BackflowListCommand(t *testing.T) {
 func TestInteractionHandler_BackflowStatusNotFound(t *testing.T) {
 	pub, priv := testKeyPair(t)
 	s := &fakeTaskStore{tasks: map[string]*models.Task{}}
-	handler := InteractionHandler(pub, s)
+	handler := InteractionHandler(pub, s, nil, nil)
 
 	body := `{"type":2,"data":{"name":"backflow","options":[{"name":"status","type":1,"options":[{"name":"task_id","type":3,"value":"bf_missing"}]}]}}`
 	rr := postInteraction(handler, priv, body)
@@ -239,7 +262,7 @@ func TestInteractionHandler_BackflowStatusNotFound(t *testing.T) {
 
 func TestInteractionHandler_NilStoreStatus(t *testing.T) {
 	pub, priv := testKeyPair(t)
-	handler := InteractionHandler(pub, nil)
+	handler := InteractionHandler(pub, nil, nil, nil)
 
 	body := `{"type":2,"data":{"name":"backflow","options":[{"name":"status","type":1,"options":[{"name":"task_id","type":3,"value":"bf_123"}]}]}}`
 	rr := postInteraction(handler, priv, body)
@@ -258,7 +281,7 @@ func TestInteractionHandler_NilStoreStatus(t *testing.T) {
 
 func TestInteractionHandler_NilStoreList(t *testing.T) {
 	pub, priv := testKeyPair(t)
-	handler := InteractionHandler(pub, nil)
+	handler := InteractionHandler(pub, nil, nil, nil)
 
 	body := `{"type":2,"data":{"name":"backflow","options":[{"name":"list","type":1}]}}`
 	rr := postInteraction(handler, priv, body)
@@ -277,7 +300,7 @@ func TestInteractionHandler_NilStoreList(t *testing.T) {
 
 func TestInteractionHandler_UnknownCommand(t *testing.T) {
 	pub, priv := testKeyPair(t)
-	handler := InteractionHandler(pub, nil)
+	handler := InteractionHandler(pub, nil, nil, nil)
 
 	rr := postInteraction(handler, priv, `{"type":2,"data":{"name":"unknown"}}`)
 
@@ -336,22 +359,166 @@ func TestRegisterCommands(t *testing.T) {
 	if commands[0].Name != "backflow" {
 		t.Errorf("command name = %q, want %q", commands[0].Name, "backflow")
 	}
-	if len(commands[0].Options) != 2 {
-		t.Fatalf("options = %v, want 2 subcommands", commands[0].Options)
+	if len(commands[0].Options) != 3 {
+		t.Fatalf("options = %v, want 3 subcommands", commands[0].Options)
 	}
-	if commands[0].Options[0].Name != "status" || commands[0].Options[1].Name != "list" {
-		t.Fatalf("subcommands = %v, want status and list", commands[0].Options)
+	if commands[0].Options[0].Name != "create" || commands[0].Options[1].Name != "status" || commands[0].Options[2].Name != "list" {
+		t.Fatalf("subcommands = %v, want create, status, and list", commands[0].Options)
 	}
 }
 
 func TestInteractionHandler_UnknownType(t *testing.T) {
 	pub, priv := testKeyPair(t)
-	handler := InteractionHandler(pub, nil)
+	handler := InteractionHandler(pub, nil, nil, nil)
 
 	rr := postInteraction(handler, priv, `{"type":99}`)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestInteractionHandler_BackflowCreateCommandOpensModal(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	handler := InteractionHandler(pub, &fakeTaskStore{}, &config.Config{}, nil)
+
+	body := `{"type":2,"data":{"name":"backflow","options":[{"name":"create","type":1}]}}`
+	rr := postInteraction(handler, priv, body)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	var resp ModalResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Type != ResponseTypeModal {
+		t.Fatalf("response type = %d, want %d", resp.Type, ResponseTypeModal)
+	}
+	if resp.Data.CustomID != discordCreateTaskModalID {
+		t.Fatalf("custom_id = %q, want %q", resp.Data.CustomID, discordCreateTaskModalID)
+	}
+	if len(resp.Data.Components) != 5 {
+		t.Fatalf("components = %d, want 5", len(resp.Data.Components))
+	}
+}
+
+func TestInteractionHandler_BackflowCreateModalSubmit(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	store := &fakeTaskStore{}
+	recorder := &taskCreatedRecorder{}
+	cfg := &config.Config{
+		DefaultHarness:     "codex",
+		DefaultClaudeModel: "claude-sonnet-4-6",
+		DefaultCodexModel:  "gpt-5.4-mini",
+		DefaultEffort:      "medium",
+		DefaultMaxBudget:   10.0,
+		DefaultMaxRuntime:  30 * time.Minute,
+		DefaultMaxTurns:    200,
+	}
+	handler := InteractionHandler(pub, store, cfg, recorder.record)
+
+	body := `{"type":5,"data":{"custom_id":"backflow:create:code","components":[` +
+		`{"components":[{"custom_id":"repo_url","value":"https://github.com/test/repo"}]},` +
+		`{"components":[{"custom_id":"prompt","value":"Fix the flaky test"}]},` +
+		`{"components":[{"custom_id":"branch","value":"feature/fix-flake"}]},` +
+		`{"components":[{"custom_id":"target_branch","value":"main"}]},` +
+		`{"components":[{"custom_id":"advanced","value":"harness=claude_code\nbudget=25.5\nruntime=45"}]}` +
+		`]}}`
+	rr := postInteraction(handler, priv, body)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var resp ChannelMessageResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Type != ResponseTypeChannelMessage {
+		t.Fatalf("response type = %d, want %d", resp.Type, ResponseTypeChannelMessage)
+	}
+	if resp.Data.Flags != discordFlagEphemeral {
+		t.Fatalf("flags = %d, want %d", resp.Data.Flags, discordFlagEphemeral)
+	}
+	if !strings.Contains(resp.Data.Content, "Created task bf_") {
+		t.Fatalf("content = %q, want created-task confirmation", resp.Data.Content)
+	}
+	if len(store.created) != 1 {
+		t.Fatalf("created tasks = %d, want 1", len(store.created))
+	}
+
+	task := store.created[0]
+	if task.TaskMode != models.TaskModeCode {
+		t.Fatalf("task_mode = %q, want %q", task.TaskMode, models.TaskModeCode)
+	}
+	if task.RepoURL != "https://github.com/test/repo" {
+		t.Fatalf("repo_url = %q", task.RepoURL)
+	}
+	if task.Prompt != "Fix the flaky test" {
+		t.Fatalf("prompt = %q", task.Prompt)
+	}
+	if task.Branch != "feature/fix-flake" {
+		t.Fatalf("branch = %q", task.Branch)
+	}
+	if task.TargetBranch != "main" {
+		t.Fatalf("target_branch = %q", task.TargetBranch)
+	}
+	if task.Harness != models.HarnessClaudeCode {
+		t.Fatalf("harness = %q, want %q", task.Harness, models.HarnessClaudeCode)
+	}
+	if task.MaxBudgetUSD != 25.5 {
+		t.Fatalf("budget = %v, want 25.5", task.MaxBudgetUSD)
+	}
+	if task.MaxRuntimeMin != 45 {
+		t.Fatalf("runtime = %d, want 45", task.MaxRuntimeMin)
+	}
+	if !task.CreatePR {
+		t.Fatal("expected create_pr = true")
+	}
+	if len(recorder.tasks) != 1 || recorder.tasks[0].ID != task.ID {
+		t.Fatalf("recorded tasks = %+v, want created task callback", recorder.tasks)
+	}
+}
+
+func TestInteractionHandler_BackflowCreateModalSubmitInvalidInput(t *testing.T) {
+	pub, priv := testKeyPair(t)
+	store := &fakeTaskStore{}
+	cfg := &config.Config{
+		DefaultHarness:     "codex",
+		DefaultClaudeModel: "claude-sonnet-4-6",
+		DefaultCodexModel:  "gpt-5.4-mini",
+		DefaultEffort:      "medium",
+		DefaultMaxBudget:   10.0,
+		DefaultMaxRuntime:  30 * time.Minute,
+		DefaultMaxTurns:    200,
+	}
+	handler := InteractionHandler(pub, store, cfg, nil)
+
+	body := `{"type":5,"data":{"custom_id":"backflow:create:code","components":[` +
+		`{"components":[{"custom_id":"repo_url","value":""}]},` +
+		`{"components":[{"custom_id":"prompt","value":"Fix the flaky test"}]},` +
+		`{"components":[{"custom_id":"branch","value":""}]},` +
+		`{"components":[{"custom_id":"target_branch","value":""}]},` +
+		`{"components":[{"custom_id":"advanced","value":"harness=invalid"}]}` +
+		`]}}`
+	rr := postInteraction(handler, priv, body)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	var resp ChannelMessageResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Data.Flags != discordFlagEphemeral {
+		t.Fatalf("flags = %d, want %d", resp.Data.Flags, discordFlagEphemeral)
+	}
+	if !strings.Contains(resp.Data.Content, "repo_url is required") {
+		t.Fatalf("content = %q, want validation error", resp.Data.Content)
+	}
+	if len(store.created) != 0 {
+		t.Fatalf("created tasks = %d, want 0", len(store.created))
 	}
 }
 

--- a/internal/taskbuilder/taskbuilder.go
+++ b/internal/taskbuilder/taskbuilder.go
@@ -1,0 +1,75 @@
+package taskbuilder
+
+import (
+	"time"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/backflow-labs/backflow/internal/config"
+	"github.com/backflow-labs/backflow/internal/models"
+)
+
+// Build constructs a pending task from a validated create-task request.
+func Build(cfg *config.Config, req models.CreateTaskRequest, now time.Time) *models.Task {
+	harness := models.Harness(withDefault(req.Harness, cfg.DefaultHarness))
+
+	return &models.Task{
+		ID:              "bf_" + ulid.Make().String(),
+		Status:          models.TaskStatusPending,
+		TaskMode:        withDefault(req.TaskMode, models.TaskModeCode),
+		Harness:         harness,
+		RepoURL:         req.RepoURL,
+		Branch:          req.Branch,
+		TargetBranch:    req.TargetBranch,
+		ReviewPRURL:     req.ReviewPRURL,
+		ReviewPRNumber:  req.ReviewPRNumber,
+		Prompt:          req.Prompt,
+		Context:         req.Context,
+		Model:           defaultModel(cfg, harness, req.Model),
+		Effort:          withDefault(req.Effort, cfg.DefaultEffort),
+		MaxBudgetUSD:    withDefaultFloat(req.MaxBudgetUSD, cfg.DefaultMaxBudget),
+		MaxRuntimeMin:   withDefaultInt(req.MaxRuntimeMin, int(cfg.DefaultMaxRuntime.Minutes())),
+		MaxTurns:        withDefaultInt(req.MaxTurns, cfg.DefaultMaxTurns),
+		CreatePR:        req.CreatePR,
+		SelfReview:      req.SelfReview,
+		SaveAgentOutput: req.SaveAgentOutput == nil || *req.SaveAgentOutput,
+		PRTitle:         req.PRTitle,
+		PRBody:          req.PRBody,
+		AllowedTools:    req.AllowedTools,
+		ClaudeMD:        req.ClaudeMD,
+		EnvVars:         req.EnvVars,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+}
+
+func defaultModel(cfg *config.Config, harness models.Harness, requested string) string {
+	if requested != "" {
+		return requested
+	}
+	if harness == models.HarnessCodex {
+		return cfg.DefaultCodexModel
+	}
+	return cfg.DefaultClaudeModel
+}
+
+func withDefault(val, fallback string) string {
+	if val == "" {
+		return fallback
+	}
+	return val
+}
+
+func withDefaultFloat(val, fallback float64) float64 {
+	if val == 0 {
+		return fallback
+	}
+	return val
+}
+
+func withDefaultInt(val, fallback int) int {
+	if val == 0 {
+		return fallback
+	}
+	return val
+}


### PR DESCRIPTION
## Summary
- add a `/backflow create` slash subcommand that opens a Discord modal for code-task creation
- parse modal submissions into validated Backflow code tasks, including optional branch and target branch inputs plus advanced harness/budget/runtime knobs
- reuse shared task-building defaults and emit `task.created` so the existing Discord notification/thread flow continues to work

## Testing
- `PATH=/usr/local/go/bin:$PATH /usr/local/go/bin/go test ./internal/discord ./internal/models -count=1`
- `PATH=/usr/local/go/bin:$PATH /usr/local/go/bin/go test ./internal/taskbuilder -count=1`
- `PATH=/usr/local/go/bin:$PATH /usr/local/go/bin/go test ./cmd/backflow -run TestDoesNotExist -count=1`
- `PATH=/usr/local/go/bin:$PATH /usr/local/go/bin/go test ./internal/api -run 'TestCreateAndGetTask|TestCreateTaskCodexHarness' -count=1` *(fails in this environment because `testcontainers` cannot find a Docker daemon: `panic: rootless Docker not found`)*