### PR TITLE
Skip testcontainers tests in agent container

### DIFF
--- a/cmd/migrate-to-postgres/migrate_test.go
+++ b/cmd/migrate-to-postgres/migrate_test.go
@@ -1,3 +1,5 @@
+//go:build !nocontainers
+
 package main
 
 import (

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN GOARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
     && curl -fsSL "https://go.dev/dl/go1.24.1.linux-${GOARCH}.tar.gz" | tar -C /usr/local -xz \
     && /usr/local/go/bin/go version
 ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOFLAGS="-tags=nocontainers"
 
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg \

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1,3 +1,5 @@
+//go:build !nocontainers
+
 package api
 
 import (

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -1,3 +1,5 @@
+//go:build !nocontainers
+
 package store
 
 import (


### PR DESCRIPTION
## Summary

- Add `//go:build !nocontainers` build constraint to the three test files that depend on testcontainers (`internal/store/postgres_test.go`, `internal/api/handlers_test.go`, `cmd/migrate-to-postgres/migrate_test.go`)
- Set `GOFLAGS="-tags=nocontainers"` in the agent Dockerfile so `go test ./...` automatically excludes these tests where Docker is unavailable
- Local development is unaffected — `make test` continues to run all tests as before

## Test plan

- [x] `go test -tags nocontainers ./...` excludes testcontainers-dependent packages (`[no test files]`)
- [x] `go test ./...` (no tag) still runs all tests including testcontainers

🤖 Generated with [Claude Code](https://claude.com/claude-code)