### PR TITLE
Make Discord create modal success response ephemeral

### DIFF
--- a/internal/discord/create.go
+++ b/internal/discord/create.go
@@ -218,7 +218,7 @@ func handleCreateSubmit(ctx context.Context, w http.ResponseWriter, data ModalSu
 
 	respondJSON(w, ChannelMessageResponse{
 		Type: ResponseTypeChannelMessage,
-		Data: MessageData{Content: formatCreatedTask(task)},
+		Data: MessageData{Content: formatCreatedTask(task), Flags: FlagEphemeral},
 	})
 }
 

--- a/internal/discord/ephemeral_test.go
+++ b/internal/discord/ephemeral_test.go
@@ -88,9 +88,9 @@ func TestModalSubmitErrors_AreEphemeral(t *testing.T) {
 	}
 }
 
-// TestModalSubmitSuccess_NotEphemeral verifies that successful task creation
-// responses are visible to the whole channel (no ephemeral flag).
-func TestModalSubmitSuccess_NotEphemeral(t *testing.T) {
+// TestModalSubmitSuccess_IsEphemeral verifies that successful task creation
+// responses are ephemeral (only visible to the submitting user).
+func TestModalSubmitSuccess_IsEphemeral(t *testing.T) {
 	pub, priv := testKeyPair(t)
 	handler := InteractionHandler(pub, nil, fakeCreateTask(fakeTask(), nil))
 
@@ -115,7 +115,7 @@ func TestModalSubmitSuccess_NotEphemeral(t *testing.T) {
 	if err := json.Unmarshal(raw["data"], &data); err != nil {
 		t.Fatalf("decode data: %v", err)
 	}
-	if data.Flags != 0 {
-		t.Errorf("flags = %d, want 0 (not ephemeral for success)", data.Flags)
+	if data.Flags != FlagEphemeral {
+		t.Errorf("flags = %d, want %d (ephemeral)", data.Flags, FlagEphemeral)
 	}
 }


### PR DESCRIPTION
## Summary
- Make the success message after submitting the `/backflow create` modal ephemeral (only visible to the submitting user), matching the existing behavior for error responses

## Test plan
- [x] `TestModalSubmitSuccess_IsEphemeral` updated and passing
- [x] All existing discord tests passing
- [x] Deploy and verify the create modal response is only visible to the submitter in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)