### PR TITLE
Fix CI deploy triggers, pin flyctl action, and tighten IAM policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main, fly-deploy]
+    branches: [main]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -44,14 +44,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: ci
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fly-deploy')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    concurrency:
+      group: fly-deploy
+      cancel-in-progress: true
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # master
 
       - name: Deploy to Fly.io
         run: flyctl deploy --remote-only

--- a/cmd/backflow/main.go
+++ b/cmd/backflow/main.go
@@ -79,6 +79,10 @@ func main() {
 		log.Info().Str("log_file", cfg.LogFile).Msg("logging to file")
 	}
 
+	if cfg.RestrictAPI {
+		log.Info().Msg("API access restricted: all /api/v1/* endpoints return 403")
+	}
+
 	db, err := store.NewPostgres(context.Background(), cfg.DatabaseURL, "migrations")
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to open database")

--- a/scripts/setup-aws.sh
+++ b/scripts/setup-aws.sh
@@ -554,18 +554,20 @@ FLY_POLICY=$(cat <<FLYEOF
         "ecs:DescribeTasks",
         "ecs:ListTasks"
       ],
-      "Resource": "*",
-      "Condition": {
-        "StringEquals": {
-          "ecs:cluster": "arn:aws:ecs:${REGION}:${ACCOUNT_ID}:cluster/${ECS_CLUSTER}"
-        }
-      }
+      "Resource": [
+        "arn:aws:ecs:${REGION}:${ACCOUNT_ID}:cluster/${ECS_CLUSTER}",
+        "arn:aws:ecs:${REGION}:${ACCOUNT_ID}:task/${ECS_CLUSTER}/*",
+        "arn:aws:ecs:${REGION}:${ACCOUNT_ID}:task-definition/${ECS_CONTAINER_NAME}:*"
+      ]
     },
     {
       "Sid": "ECSPassRole",
       "Effect": "Allow",
       "Action": "iam:PassRole",
-      "Resource": "arn:aws:iam::${ACCOUNT_ID}:role/*",
+      "Resource": [
+        "arn:aws:iam::${ACCOUNT_ID}:role/${ECS_EXECUTION_ROLE}",
+        "arn:aws:iam::${ACCOUNT_ID}:role/${ECS_TASK_ROLE}"
+      ],
       "Condition": {
         "StringEquals": {
           "iam:PassedToService": "ecs-tasks.amazonaws.com"


### PR DESCRIPTION
## Summary

Followup fixes for #134 (Fly.io deployment).

- **Remove leftover `fly-deploy` branch from CI triggers** — was left in for testing and never cleaned up; any push to that branch would trigger a deploy
- **Pin `superfly/flyctl-actions/setup-flyctl` to commit SHA** — `@master` is a supply chain risk; pinned to `63da3ecc`
- **Add concurrency group to deploy job** — prevents parallel deploys when multiple pushes to main land in quick succession
- **Scope IAM ECS policy resources** — replaced `Resource: "*"` with specific cluster, task, and task-definition ARNs (the `ecs:cluster` condition only applied to `RunTask`, leaving `StopTask`/`DescribeTasks`/`ListTasks` unrestricted)
- **Scope IAM PassRole to specific roles** — replaced `role/*` with the ECS execution and task role ARNs
- **Log when API restriction is active** — startup log line confirms `/api/v1/*` endpoints return 403

## Deployment steps

If the `backflow-fly` IAM user policy has already been applied, re-run `make setup-aws` to update the policy with the tightened resource scopes.

## Test plan

- [x] `go test ./internal/api/ ./internal/config/ -v` passes
- [ ] CI passes
- [ ] After merge: verify deploy only triggers on main pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)