### PR TITLE
Complete black-box coverage for failure modes, timeout, cancellation, and webhook retries

### DIFF
--- a/test/blackbox/task_outcomes_test.go
+++ b/test/blackbox/task_outcomes_test.go
@@ -1,0 +1,197 @@
+//go:build !nocontainers
+
+package blackbox_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func taskIDFromCreate(t *testing.T, task map[string]any) string {
+	t.Helper()
+	taskID, ok := task["id"].(string)
+	if !ok || taskID == "" {
+		t.Fatal("expected non-empty task ID")
+	}
+	if !strings.HasPrefix(taskID, "bf_") {
+		t.Fatalf("task ID %q should have bf_ prefix", taskID)
+	}
+	return taskID
+}
+
+func waitForWebhookEventCount(t *testing.T, taskID, eventType string, want int, timeout time.Duration) []WebhookEvent {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		events := listener.EventsForTask(taskID)
+		var filtered []WebhookEvent
+		for _, event := range events {
+			if event.Event == eventType {
+				filtered = append(filtered, event)
+			}
+		}
+		if len(filtered) >= want {
+			return filtered
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for %d %q events for task %s", want, eventType, taskID)
+	return nil
+}
+
+func waitForStatusWithoutStuckTimeout(t *testing.T, taskID, want string, timeout time.Duration) map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastStatus string
+	for time.Now().Before(deadline) {
+		task := client.GetTask(t, taskID)
+		current, _ := task["status"].(string)
+		if current == want {
+			return task
+		}
+		lastStatus = current
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for task %s to reach status %q (last: %q, waited %s)", taskID, want, lastStatus, timeout)
+	return nil
+}
+
+func TestAgentFailure(t *testing.T) {
+	resetBetweenTests(t)
+	t.Cleanup(dumpLogsOnFailure(t))
+
+	task := client.CreateTask(t, map[string]any{
+		"prompt":   "test agent failure",
+		"env_vars": map[string]string{"FAKE_OUTCOME": "fail"},
+	})
+	taskID := taskIDFromCreate(t, task)
+
+	completed := waitForStatusWithoutStuckTimeout(t, taskID, "failed", 60*time.Second)
+	if completed["status"] != "failed" {
+		t.Fatalf("final status = %q, want failed", completed["status"])
+	}
+	if errMsg, _ := completed["error"].(string); errMsg != "fake agent failure" {
+		t.Fatalf("error = %q, want fake agent failure", errMsg)
+	}
+
+	listener.WaitForEventType(t, taskID, "task.failed", 10*time.Second)
+}
+
+func TestNeedsInput(t *testing.T) {
+	resetBetweenTests(t)
+	t.Cleanup(dumpLogsOnFailure(t))
+
+	task := client.CreateTask(t, map[string]any{
+		"prompt":   "test needs input",
+		"env_vars": map[string]string{"FAKE_OUTCOME": "needs_input"},
+	})
+	taskID := taskIDFromCreate(t, task)
+
+	completed := waitForStatusWithoutStuckTimeout(t, taskID, "failed", 60*time.Second)
+	if completed["status"] != "failed" {
+		t.Fatalf("final status = %q, want failed", completed["status"])
+	}
+	if errMsg, _ := completed["error"].(string); errMsg != "agent needs input" {
+		t.Fatalf("error = %q, want agent needs input", errMsg)
+	}
+
+	event := listener.WaitForEventType(t, taskID, "task.needs_input", 10*time.Second)
+	if event.Message != "fake question" {
+		t.Fatalf("webhook message = %q, want fake question", event.Message)
+	}
+}
+
+func TestCrash(t *testing.T) {
+	resetBetweenTests(t)
+	t.Cleanup(dumpLogsOnFailure(t))
+
+	task := client.CreateTask(t, map[string]any{
+		"prompt":   "test crash",
+		"env_vars": map[string]string{"FAKE_OUTCOME": "crash"},
+	})
+	taskID := taskIDFromCreate(t, task)
+
+	completed := client.WaitForStatus(t, taskID, "failed", 60*time.Second)
+	if completed["status"] != "failed" {
+		t.Fatalf("final status = %q, want failed", completed["status"])
+	}
+	errMsg, _ := completed["error"].(string)
+	if !strings.Contains(errMsg, "container exited with code 137") {
+		t.Fatalf("error = %q, want exit code 137", errMsg)
+	}
+
+	listener.WaitForEventType(t, taskID, "task.failed", 10*time.Second)
+}
+
+func TestTimeout(t *testing.T) {
+	resetBetweenTests(t)
+	t.Cleanup(dumpLogsOnFailure(t))
+
+	task := client.CreateTask(t, map[string]any{
+		"prompt":          "test timeout",
+		"max_runtime_sec": 3,
+		"env_vars":        map[string]string{"FAKE_OUTCOME": "timeout"},
+	})
+	taskID := taskIDFromCreate(t, task)
+
+	completed := waitForStatusWithoutStuckTimeout(t, taskID, "failed", 60*time.Second)
+	if completed["status"] != "failed" {
+		t.Fatalf("final status = %q, want failed", completed["status"])
+	}
+	errMsg, _ := completed["error"].(string)
+	if !strings.Contains(errMsg, "exceeded max runtime") {
+		t.Fatalf("error = %q, want max runtime exceeded", errMsg)
+	}
+
+	listener.WaitForEventType(t, taskID, "task.failed", 10*time.Second)
+}
+
+func TestCancellation(t *testing.T) {
+	resetBetweenTests(t)
+	t.Cleanup(dumpLogsOnFailure(t))
+
+	task := client.CreateTask(t, map[string]any{
+		"prompt":   "test cancellation",
+		"env_vars": map[string]string{"FAKE_OUTCOME": "timeout"},
+	})
+	taskID := taskIDFromCreate(t, task)
+
+	client.WaitForStatus(t, taskID, "running", 30*time.Second)
+	client.DeleteTask(t, taskID)
+
+	cancelled := client.WaitForStatus(t, taskID, "cancelled", 30*time.Second)
+	if cancelled["status"] != "cancelled" {
+		t.Fatalf("final status = %q, want cancelled", cancelled["status"])
+	}
+
+	listener.WaitForEventType(t, taskID, "task.cancelled", 10*time.Second)
+	waitForOrchestratorIdle(t, 60*time.Second)
+}
+
+func TestWebhookResilience(t *testing.T) {
+	resetBetweenTests(t)
+	t.Cleanup(dumpLogsOnFailure(t))
+
+	listener.SetBehaviorForEvent("task.completed", []int{500, 500, 200}, 0)
+
+	task := client.CreateTask(t, map[string]any{
+		"prompt":   "test webhook retries",
+		"env_vars": map[string]string{"FAKE_OUTCOME": "success"},
+	})
+	taskID := taskIDFromCreate(t, task)
+
+	completed := client.WaitForStatus(t, taskID, "completed", 60*time.Second)
+	if completed["status"] != "completed" {
+		t.Fatalf("final status = %q, want completed", completed["status"])
+	}
+
+	events := waitForWebhookEventCount(t, taskID, "task.completed", 3, 30*time.Second)
+	if len(events) != 3 {
+		t.Fatalf("task.completed attempts = %d, want 3", len(events))
+	}
+
+	waitForOrchestratorIdle(t, 60*time.Second)
+}

--- a/test/blackbox/webhook_listener_test.go
+++ b/test/blackbox/webhook_listener_test.go
@@ -37,6 +37,13 @@ type WebhookListener struct {
 	events     []WebhookEvent
 	statusCode int
 	latency    time.Duration
+	behaviors  map[string]*webhookBehavior
+}
+
+type webhookBehavior struct {
+	statusCodes []int
+	latency     time.Duration
+	calls       int
 }
 
 // newWebhookListener creates and starts a new WebhookListener. The caller must
@@ -47,15 +54,6 @@ func newWebhookListener() *WebhookListener {
 	}
 
 	wl.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wl.mu.Lock()
-		latency := wl.latency
-		code := wl.statusCode
-		wl.mu.Unlock()
-
-		if latency > 0 {
-			time.Sleep(latency)
-		}
-
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "read error", http.StatusInternalServerError)
@@ -68,9 +66,15 @@ func newWebhookListener() *WebhookListener {
 			return
 		}
 
+		code, latency := wl.responseFor(event.Event)
+
 		wl.mu.Lock()
 		wl.events = append(wl.events, event)
 		wl.mu.Unlock()
+
+		if latency > 0 {
+			time.Sleep(latency)
+		}
 
 		w.WriteHeader(code)
 	}))
@@ -90,6 +94,23 @@ func (wl *WebhookListener) SetBehavior(statusCode int, latency time.Duration) {
 	defer wl.mu.Unlock()
 	wl.statusCode = statusCode
 	wl.latency = latency
+}
+
+// SetBehaviorForEvent configures a response script for a specific webhook
+// event type. Each received event consumes one entry from statusCodes; once the
+// script is exhausted, the last status code is reused.
+func (wl *WebhookListener) SetBehaviorForEvent(eventType string, statusCodes []int, latency time.Duration) {
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+
+	if wl.behaviors == nil {
+		wl.behaviors = make(map[string]*webhookBehavior)
+	}
+	codes := append([]int(nil), statusCodes...)
+	wl.behaviors[eventType] = &webhookBehavior{
+		statusCodes: codes,
+		latency:     latency,
+	}
 }
 
 // EventsForTask returns a copy of all events received for the given task ID.
@@ -140,9 +161,30 @@ func (wl *WebhookListener) Reset() {
 	wl.events = nil
 	wl.statusCode = http.StatusOK
 	wl.latency = 0
+	wl.behaviors = nil
 }
 
 // Close shuts down the underlying httptest.Server.
 func (wl *WebhookListener) Close() {
 	wl.server.Close()
+}
+
+func (wl *WebhookListener) responseFor(eventType string) (int, time.Duration) {
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+
+	if behavior, ok := wl.behaviors[eventType]; ok {
+		code := wl.statusCode
+		if len(behavior.statusCodes) > 0 {
+			idx := behavior.calls
+			if idx >= len(behavior.statusCodes) {
+				idx = len(behavior.statusCodes) - 1
+			}
+			code = behavior.statusCodes[idx]
+		}
+		behavior.calls++
+		return code, behavior.latency
+	}
+
+	return wl.statusCode, wl.latency
 }


### PR DESCRIPTION
Implements the remaining black-box outcomes from issue #145.

What changed:
- Added coverage for agent failure, needs input, crash, timeout, cancellation, and webhook retry behavior.
- Extended the black-box webhook listener to script per-event response codes so retry behavior can be exercised deterministically.
- Kept the changes scoped to the test harness and black-box tests.

Verification:
- `go test ./test/blackbox -v -count=1`

Closes #145
Issue: https://github.com/backflow-labs/backflow/issues/145