### PR TITLE
Add debug stats endpoint and soak test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
        docker-agent-build docker-agent-build-local docker-agent-push docker-agent-deploy \
        docker-server-build docker-server-build-local docker-server-deploy \
        docker-fake-agent-build test-fake-agent test-blackbox test-schema \
+       test-soak \
        deploy-dev \
        db-pending db-provisioning db-running db-completed db-failed db-interrupted db-cancelled db-recovering \
        setup-aws deps tunnel cloudflared-setup test-docker-status-writer copy-env overwrite-env
@@ -42,6 +43,9 @@ test-fake-agent: docker-fake-agent-build
 
 test-blackbox:
 	go test ./test/blackbox/ -v -count=1 -timeout 120s
+
+test-soak:
+	go run ./test/soak --api-url $${SOAK_API_URL:-http://localhost:8080} --short
 
 test-schema:
 	bash scripts/test-schema.sh

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ make build          # Compile to bin/backflow
 make run            # Build + run (auto-sources .env, refreshes AWS creds if needed)
 make test           # Run all tests (no cache)
 make lint           # go vet
+make test-soak      # Run the standalone soak binary against a local Backflow API
 make tunnel         # Start cloudflared tunnel → $BACKFLOW_DOMAIN → localhost:8080
 make deps           # go mod tidy
 make clean          # Remove bin/
@@ -125,6 +126,7 @@ curl -X POST http://localhost:8080/api/v1/tasks \
 | `DELETE` | `/api/v1/tasks/{id}` | Cancel a task |
 | `GET` | `/api/v1/tasks/{id}/logs` | Container logs (`?tail=100`) |
 | `GET` | `/api/v1/health` | Health check |
+| `GET` | `/debug/stats` | Operational stats for orchestrator, pgxpool, uptime, and runtime memory |
 | `POST` | `/webhooks/discord` | Discord interaction endpoint (signature-verified) |
 | `POST` | `/webhooks/sms/inbound` | Twilio inbound SMS webhook |
 
@@ -170,6 +172,9 @@ curl -s 'http://localhost:8080/api/v1/tasks/{id}/logs?tail=100'
 
 # Health check
 curl -s http://localhost:8080/api/v1/health
+
+# Operational stats
+curl -s http://localhost:8080/debug/stats
 
 # Shell into an agent EC2 instance
 aws ssm start-session --target i-0abc...

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -44,6 +44,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
 
+  /debug/stats:
+    get:
+      operationId: debugStats
+      summary: Operational debug stats
+      description: Returns live orchestration, database pool, uptime, and runtime memory metrics for operators and soak testing.
+      responses:
+        "200":
+          description: Debug stats snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DebugStatsEnvelope"
+
   /api/v1/tasks:
     post:
       operationId: createTask
@@ -266,6 +279,64 @@ components:
           type: string
           enum: [api_key, max_subscription]
           example: api_key
+
+    DebugStatsEnvelope:
+      type: object
+      required: [data]
+      properties:
+        data:
+          $ref: "#/components/schemas/DebugStats"
+
+    DebugStats:
+      type: object
+      required: [orchestrator_running, pgxpool, process_uptime_sec, memory]
+      properties:
+        orchestrator_running:
+          type: integer
+          minimum: 0
+          example: 3
+        pgxpool:
+          $ref: "#/components/schemas/DebugPoolStats"
+        process_uptime_sec:
+          type: integer
+          minimum: 0
+          example: 120
+        memory:
+          $ref: "#/components/schemas/DebugMemoryStats"
+
+    DebugPoolStats:
+      type: object
+      required: [acquired, idle, total, max_connections]
+      properties:
+        acquired:
+          type: integer
+          minimum: 0
+          example: 1
+        idle:
+          type: integer
+          minimum: 0
+          example: 2
+        total:
+          type: integer
+          minimum: 0
+          example: 3
+        max_connections:
+          type: integer
+          minimum: 0
+          example: 5
+
+    DebugMemoryStats:
+      type: object
+      required: [heap_alloc, sys]
+      properties:
+        heap_alloc:
+          type: integer
+          minimum: 0
+          example: 123456
+        sys:
+          type: integer
+          minimum: 0
+          example: 654321
 
     ErrorEnvelope:
       type: object

--- a/cmd/backflow/main.go
+++ b/cmd/backflow/main.go
@@ -59,6 +59,8 @@ func setupLogger(logFile string) (zerolog.Logger, io.Closer, error) {
 }
 
 func main() {
+	processStartedAt := time.Now().UTC()
+
 	// Set up initial stderr-only logger; reconfigured after config load if LogFile is set.
 	logger, _, err := setupLogger("")
 	if err != nil {
@@ -145,8 +147,9 @@ func main() {
 	}
 
 	orch := orchestrator.New(db, cfg, bus, runner, scaler, spot, s3Uploader)
+	debugStats := api.NewDebugStatsSource(processStartedAt, orch, db)
 
-	router := api.NewServer(db, cfg, orch.Docker(), bus)
+	router := api.NewServer(db, cfg, orch.Docker(), bus, debugStats)
 
 	// Mount SMS inbound webhook if provider is configured
 	if cfg.SMSProvider != "" {

--- a/internal/api/debug_stats.go
+++ b/internal/api/debug_stats.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/backflow-labs/backflow/internal/store"
+)
+
+// RunningCounter exposes the orchestrator's in-memory running task count.
+type RunningCounter interface {
+	RunningCount() int
+}
+
+// PoolStatsProvider exposes pgxpool statistics without leaking the concrete store.
+type PoolStatsProvider interface {
+	DebugPoolStats() store.PoolStats
+}
+
+// DebugStatsProvider returns a snapshot of the process's operational state.
+type DebugStatsProvider interface {
+	Snapshot() DebugStats
+}
+
+// DebugStatsSource aggregates the sources needed by /debug/stats.
+type DebugStatsSource struct {
+	startedAt time.Time
+	running   RunningCounter
+	pool      PoolStatsProvider
+}
+
+// NewDebugStatsSource creates a provider for the debug stats endpoint.
+func NewDebugStatsSource(startedAt time.Time, running RunningCounter, pool PoolStatsProvider) *DebugStatsSource {
+	return &DebugStatsSource{
+		startedAt: startedAt,
+		running:   running,
+		pool:      pool,
+	}
+}
+
+// Snapshot returns a point-in-time view of operational metrics.
+func (s *DebugStatsSource) Snapshot() DebugStats {
+	now := time.Now().UTC()
+
+	var running int
+	if s != nil && s.running != nil {
+		running = s.running.RunningCount()
+	}
+
+	var pool DebugPoolStats
+	if s != nil && s.pool != nil {
+		p := s.pool.DebugPoolStats()
+		pool = DebugPoolStats{
+			Acquired:       p.Acquired,
+			Idle:           p.Idle,
+			Total:          p.Total,
+			MaxConnections: p.MaxConnections,
+		}
+	}
+
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	uptime := int64(0)
+	if s != nil && !s.startedAt.IsZero() {
+		uptime = int64(now.Sub(s.startedAt).Seconds())
+		if uptime < 0 {
+			uptime = 0
+		}
+	}
+
+	return DebugStats{
+		OrchestratorRunning: running,
+		PGXPool:             pool,
+		ProcessUptimeSec:    uptime,
+		Memory: DebugMemoryStats{
+			HeapAlloc: mem.HeapAlloc,
+			Sys:       mem.Sys,
+		},
+	}
+}
+
+// DebugStats is the JSON payload returned by GET /debug/stats.
+type DebugStats struct {
+	OrchestratorRunning int              `json:"orchestrator_running"`
+	PGXPool             DebugPoolStats   `json:"pgxpool"`
+	ProcessUptimeSec    int64            `json:"process_uptime_sec"`
+	Memory              DebugMemoryStats `json:"memory"`
+}
+
+// DebugPoolStats contains the pgxpool counters needed for soak monitoring.
+type DebugPoolStats struct {
+	Acquired       int32 `json:"acquired"`
+	Idle           int32 `json:"idle"`
+	Total          int32 `json:"total"`
+	MaxConnections int32 `json:"max_connections"`
+}
+
+// DebugMemoryStats contains the runtime heap metrics needed for soak analysis.
+type DebugMemoryStats struct {
+	HeapAlloc uint64 `json:"heap_alloc"`
+	Sys       uint64 `json:"sys"`
+}

--- a/internal/api/debug_stats_test.go
+++ b/internal/api/debug_stats_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/backflow-labs/backflow/internal/config"
+	"github.com/backflow-labs/backflow/internal/store"
+)
+
+type fakeRunningCounter int
+
+func (f fakeRunningCounter) RunningCount() int { return int(f) }
+
+type fakePoolProvider struct {
+	stats store.PoolStats
+}
+
+func (f fakePoolProvider) DebugPoolStats() store.PoolStats { return f.stats }
+
+func TestDebugStatsSourceSnapshot(t *testing.T) {
+	startedAt := time.Now().Add(-90 * time.Second).UTC()
+	source := NewDebugStatsSource(startedAt, fakeRunningCounter(7), fakePoolProvider{
+		stats: store.PoolStats{
+			Acquired:       2,
+			Idle:           3,
+			Total:          5,
+			MaxConnections: 8,
+		},
+	})
+
+	stats := source.Snapshot()
+
+	if stats.OrchestratorRunning != 7 {
+		t.Fatalf("running = %d, want 7", stats.OrchestratorRunning)
+	}
+	if stats.PGXPool.Acquired != 2 || stats.PGXPool.Idle != 3 || stats.PGXPool.Total != 5 || stats.PGXPool.MaxConnections != 8 {
+		t.Fatalf("pool stats = %+v, want %+v", stats.PGXPool, DebugPoolStats{Acquired: 2, Idle: 3, Total: 5, MaxConnections: 8})
+	}
+	if stats.ProcessUptimeSec < 90 {
+		t.Fatalf("uptime = %d, want >= 90", stats.ProcessUptimeSec)
+	}
+	if stats.Memory.HeapAlloc == 0 || stats.Memory.Sys == 0 {
+		t.Fatalf("memory stats should be non-zero, got %+v", stats.Memory)
+	}
+}
+
+func TestDebugStatsEndpoint(t *testing.T) {
+	stats := DebugStats{
+		OrchestratorRunning: 4,
+		PGXPool: DebugPoolStats{
+			Acquired:       1,
+			Idle:           2,
+			Total:          3,
+			MaxConnections: 6,
+		},
+		ProcessUptimeSec: 123,
+		Memory: DebugMemoryStats{
+			HeapAlloc: 1024,
+			Sys:       2048,
+		},
+	}
+
+	router := NewServer(
+		&mockStore{},
+		&config.Config{AuthMode: config.AuthModeAPIKey},
+		noopLogFetcher{},
+		noopEmitter{},
+		staticDebugStatsProvider{stats: stats},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/stats", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	checkResponse(t, req, rec)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var env struct {
+		Data DebugStats `json:"data"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if env.Data != stats {
+		t.Fatalf("response = %+v, want %+v", env.Data, stats)
+	}
+
+	body := rec.Body.Bytes()
+	for _, forbidden := range []string{"database_url", "BACKFLOW_", "webhook", "secret", "token"} {
+		if bytes.Contains(bytes.ToLower(body), []byte(strings.ToLower(forbidden))) {
+			t.Fatalf("debug stats response unexpectedly contained %q: %s", forbidden, body)
+		}
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -21,14 +21,15 @@ type LogFetcher interface {
 }
 
 type Handlers struct {
-	store  store.Store
-	config *config.Config
-	logs   LogFetcher
-	bus    notify.Emitter
+	store      store.Store
+	config     *config.Config
+	logs       LogFetcher
+	bus        notify.Emitter
+	debugStats DebugStatsProvider
 }
 
-func NewHandlers(s store.Store, cfg *config.Config, logs LogFetcher, bus notify.Emitter) *Handlers {
-	return &Handlers{store: s, config: cfg, logs: logs, bus: bus}
+func NewHandlers(s store.Store, cfg *config.Config, logs LogFetcher, bus notify.Emitter, debugStats DebugStatsProvider) *Handlers {
+	return &Handlers{store: s, config: cfg, logs: logs, bus: bus, debugStats: debugStats}
 }
 
 func (h *Handlers) CreateTask(w http.ResponseWriter, r *http.Request) {
@@ -174,4 +175,12 @@ func (h *Handlers) HealthCheck(w http.ResponseWriter, r *http.Request) {
 		"status":    "ok",
 		"auth_mode": string(h.config.AuthMode),
 	})
+}
+
+func (h *Handlers) DebugStats(w http.ResponseWriter, r *http.Request) {
+	if h.debugStats == nil {
+		writeError(w, http.StatusServiceUnavailable, "debug stats unavailable")
+		return
+	}
+	writeJSON(w, http.StatusOK, h.debugStats.Snapshot())
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -109,7 +109,7 @@ func testServer(t *testing.T) http.Handler {
 		DefaultMaxTurns:    200,
 	}
 
-	return NewServer(s, cfg, noopLogFetcher{}, noopEmitter{})
+	return NewServer(s, cfg, noopLogFetcher{}, noopEmitter{}, noopDebugStatsProvider{})
 }
 
 func testServerWithEmitter(t *testing.T) (http.Handler, store.Store, *capturingEmitter) {
@@ -142,7 +142,7 @@ func testServerWithEmitter(t *testing.T) (http.Handler, store.Store, *capturingE
 	}
 
 	emitter := &capturingEmitter{}
-	return NewServer(s, cfg, noopLogFetcher{}, emitter), s, emitter
+	return NewServer(s, cfg, noopLogFetcher{}, emitter, noopDebugStatsProvider{}), s, emitter
 }
 
 func TestHealthCheck(t *testing.T) {

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -15,3 +15,13 @@ func (noopLogFetcher) GetLogs(_ context.Context, _, _ string, _ int) (string, er
 type noopEmitter struct{}
 
 func (noopEmitter) Emit(_ notify.Event) {}
+
+type noopDebugStatsProvider struct{}
+
+func (noopDebugStatsProvider) Snapshot() DebugStats { return DebugStats{} }
+
+type staticDebugStatsProvider struct {
+	stats DebugStats
+}
+
+func (s staticDebugStatsProvider) Snapshot() DebugStats { return s.stats }

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRestrictAPI_BlocksAllAPIEndpoints(t *testing.T) {
 	cfg := &config.Config{RestrictAPI: true}
-	router := NewServer(&mockStore{}, cfg, noopLogFetcher{}, noopEmitter{})
+	router := NewServer(&mockStore{}, cfg, noopLogFetcher{}, noopEmitter{}, noopDebugStatsProvider{})
 
 	paths := []struct {
 		method string
@@ -44,7 +44,7 @@ func TestRestrictAPI_BlocksAllAPIEndpoints(t *testing.T) {
 
 func TestRestrictAPI_RootHealthStillAccessible(t *testing.T) {
 	cfg := &config.Config{RestrictAPI: true}
-	router := NewServer(&mockStore{}, cfg, noopLogFetcher{}, noopEmitter{})
+	router := NewServer(&mockStore{}, cfg, noopLogFetcher{}, noopEmitter{}, noopDebugStatsProvider{})
 
 	req := httptest.NewRequest("GET", "/health", nil)
 	rr := httptest.NewRecorder()
@@ -57,7 +57,7 @@ func TestRestrictAPI_RootHealthStillAccessible(t *testing.T) {
 
 func TestRestrictAPI_Disabled_AllowsAPIHealth(t *testing.T) {
 	cfg := &config.Config{RestrictAPI: false}
-	router := NewServer(&mockStore{}, cfg, noopLogFetcher{}, noopEmitter{})
+	router := NewServer(&mockStore{}, cfg, noopLogFetcher{}, noopEmitter{}, noopDebugStatsProvider{})
 
 	req := httptest.NewRequest("GET", "/api/v1/health", nil)
 	rr := httptest.NewRecorder()
@@ -65,5 +65,24 @@ func TestRestrictAPI_Disabled_AllowsAPIHealth(t *testing.T) {
 
 	if rr.Code != http.StatusOK {
 		t.Errorf("GET /api/v1/health: got status %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRestrictAPI_DoesNotBlockDebugStats(t *testing.T) {
+	cfg := &config.Config{RestrictAPI: true}
+	router := NewServer(
+		&mockStore{},
+		cfg,
+		noopLogFetcher{},
+		noopEmitter{},
+		staticDebugStatsProvider{stats: DebugStats{}},
+	)
+
+	req := httptest.NewRequest("GET", "/debug/stats", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("GET /debug/stats: got status %d, want %d", rr.Code, http.StatusOK)
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/backflow-labs/backflow/internal/store"
 )
 
-func NewServer(s store.Store, cfg *config.Config, logs LogFetcher, bus notify.Emitter) chi.Router {
+func NewServer(s store.Store, cfg *config.Config, logs LogFetcher, bus notify.Emitter, debugStats DebugStatsProvider) chi.Router {
 	r := chi.NewRouter()
 
 	r.Use(middleware.RequestID)
@@ -20,9 +20,10 @@ func NewServer(s store.Store, cfg *config.Config, logs LogFetcher, bus notify.Em
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.SetHeader("Content-Type", "application/json"))
 
-	h := NewHandlers(s, cfg, logs, bus)
+	h := NewHandlers(s, cfg, logs, bus, debugStats)
 
 	r.Get("/health", h.HealthCheck)
+	r.Get("/debug/stats", h.DebugStats)
 
 	r.Route("/api/v1", func(r chi.Router) {
 		if cfg.RestrictAPI {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -229,6 +229,13 @@ func (o *Orchestrator) decrementRunning() {
 	o.mu.Unlock()
 }
 
+// RunningCount returns the current in-memory count of running tasks.
+func (o *Orchestrator) RunningCount() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.running
+}
+
 // releaseInstanceSlot decrements the running container count for an instance.
 func (o *Orchestrator) releaseInstanceSlot(ctx context.Context, instanceID string) {
 	if instanceID == "" {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -63,6 +63,17 @@ func (s *PostgresStore) Close() error {
 	return nil
 }
 
+// DebugPoolStats returns a snapshot of pgxpool counters for operational monitoring.
+func (s *PostgresStore) DebugPoolStats() PoolStats {
+	stat := s.pool.Stat()
+	return PoolStats{
+		Acquired:       stat.AcquiredConns(),
+		Idle:           stat.IdleConns(),
+		Total:          stat.TotalConns(),
+		MaxConnections: stat.MaxConns(),
+	}
+}
+
 // --- Tasks ---
 
 const taskColumns = `id, status, task_mode, harness, repo_url, branch, target_branch,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,6 +23,14 @@ type TaskResult struct {
 	TaskMode       string
 }
 
+// PoolStats is a snapshot of pgxpool counters used for operational monitoring.
+type PoolStats struct {
+	Acquired       int32
+	Idle           int32
+	Total          int32
+	MaxConnections int32
+}
+
 // TaskFilter controls listing behavior.
 type TaskFilter struct {
 	Status *models.TaskStatus

--- a/test/soak/analysis.go
+++ b/test/soak/analysis.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/backflow-labs/backflow/internal/api"
+)
+
+type Sample struct {
+	At                  time.Time
+	Stats               api.DebugStats
+	RSSKB               int
+	LingeringContainers int
+	Tasks               taskCounts
+}
+
+type Report struct {
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Samples    []Sample
+	Submitted  int
+}
+
+type Summary struct {
+	Duration               time.Duration
+	Submitted              int
+	Completed              int
+	FailedCount            int
+	ErrorRate              float64
+	ThroughputPerMinute    float64
+	BaselineRSSKB          int
+	MaxRSSKB               int
+	RSSGrowthRatio         float64
+	BaselineContainers     int
+	MaxContainers          int
+	MaxAcquiredConnections int32
+	MaxPoolConnections     int32
+	Violations             []string
+}
+
+func Analyze(report Report) Summary {
+	summary := Summary{
+		Submitted: report.Submitted,
+	}
+	if len(report.Samples) == 0 {
+		summary.Violations = append(summary.Violations, "no samples collected")
+		return summary
+	}
+
+	start := report.StartedAt
+	if start.IsZero() {
+		start = report.Samples[0].At
+	}
+	finish := report.FinishedAt
+	if finish.IsZero() {
+		finish = report.Samples[len(report.Samples)-1].At
+	}
+	duration := finish.Sub(start)
+	if duration < 0 {
+		duration = 0
+	}
+	summary.Duration = duration
+
+	baseline := report.Samples[0]
+	summary.BaselineRSSKB = baseline.RSSKB
+	summary.BaselineContainers = baseline.LingeringContainers
+
+	maxRSS := baseline.RSSKB
+	maxContainers := baseline.LingeringContainers
+	var maxAcquired int32
+	var maxPool int32
+	saturationStreak := 0
+
+	for _, sample := range report.Samples {
+		if sample.RSSKB > maxRSS {
+			maxRSS = sample.RSSKB
+		}
+		if sample.LingeringContainers > maxContainers {
+			maxContainers = sample.LingeringContainers
+		}
+		if sample.Stats.PGXPool.Acquired > maxAcquired {
+			maxAcquired = sample.Stats.PGXPool.Acquired
+		}
+		if sample.Stats.PGXPool.MaxConnections > maxPool {
+			maxPool = sample.Stats.PGXPool.MaxConnections
+		}
+
+		if sample.Stats.PGXPool.MaxConnections > 0 &&
+			sample.Stats.PGXPool.Acquired >= sample.Stats.PGXPool.MaxConnections &&
+			sample.Stats.PGXPool.Idle == 0 {
+			saturationStreak++
+		} else {
+			saturationStreak = 0
+		}
+	}
+
+	summary.MaxRSSKB = maxRSS
+	summary.MaxContainers = maxContainers
+	summary.MaxAcquiredConnections = maxAcquired
+	summary.MaxPoolConnections = maxPool
+
+	if summary.BaselineRSSKB <= 0 {
+		summary.BaselineRSSKB = 1
+	}
+	summary.RSSGrowthRatio = float64(maxRSS) / float64(summary.BaselineRSSKB)
+
+	last := report.Samples[len(report.Samples)-1]
+	summary.Completed = last.Tasks.Completed
+	summary.FailedCount = last.Tasks.Failed
+
+	if duration > 0 {
+		summary.ErrorRate = float64(summary.FailedCount) / float64(max(1, report.Submitted))
+		summary.ThroughputPerMinute = float64(summary.Completed) / duration.Minutes()
+	}
+
+	if summary.RSSGrowthRatio > 2.0 {
+		summary.Violations = append(summary.Violations, fmt.Sprintf("rss grew to %.2fx baseline", summary.RSSGrowthRatio))
+	}
+	if saturationStreak >= 3 {
+		summary.Violations = append(summary.Violations, "pgxpool stayed saturated for 3 consecutive samples")
+	}
+	if maxContainers-summary.BaselineContainers > 2 {
+		summary.Violations = append(summary.Violations, fmt.Sprintf("lingering containers grew from %d to %d", summary.BaselineContainers, maxContainers))
+	}
+	if last.Tasks.nonTerminal() > 0 {
+		summary.Violations = append(summary.Violations, fmt.Sprintf("%d tasks still non-terminal at end of run", last.Tasks.nonTerminal()))
+	}
+
+	return summary
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func (s Summary) Failed() bool {
+	return len(s.Violations) > 0
+}
+
+func (s Summary) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "duration=%s submitted=%d completed=%d failed=%d error_rate=%.2f throughput=%.2f/min\n",
+		s.Duration.Truncate(time.Second), s.Submitted, s.Completed, s.FailedCount, s.ErrorRate, s.ThroughputPerMinute)
+	fmt.Fprintf(&b, "rss_kb baseline=%d max=%d growth=%.2fx\n", s.BaselineRSSKB, s.MaxRSSKB, s.RSSGrowthRatio)
+	fmt.Fprintf(&b, "containers baseline=%d max=%d\n", s.BaselineContainers, s.MaxContainers)
+	fmt.Fprintf(&b, "pgxpool acquired_max=%d max_conns=%d\n", s.MaxAcquiredConnections, s.MaxPoolConnections)
+	if len(s.Violations) == 0 {
+		b.WriteString("status=pass\n")
+	} else {
+		b.WriteString("status=fail\n")
+		for _, v := range s.Violations {
+			fmt.Fprintf(&b, "- %s\n", v)
+		}
+	}
+	return b.String()
+}

--- a/test/soak/analysis_test.go
+++ b/test/soak/analysis_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/backflow-labs/backflow/internal/api"
+)
+
+func TestAnalyzePassesOnStableSeries(t *testing.T) {
+	start := time.Now().Add(-3 * time.Minute)
+	report := Report{
+		StartedAt:  start,
+		FinishedAt: start.Add(3 * time.Minute),
+		Submitted:  6,
+		Samples: []Sample{
+			{
+				At:                  start,
+				Stats:               api.DebugStats{PGXPool: api.DebugPoolStats{Acquired: 1, Idle: 4, Total: 5, MaxConnections: 5}},
+				RSSKB:               1000,
+				LingeringContainers: 0,
+				Tasks:               taskCounts{Completed: 0},
+			},
+			{
+				At:                  start.Add(time.Minute),
+				Stats:               api.DebugStats{PGXPool: api.DebugPoolStats{Acquired: 2, Idle: 3, Total: 5, MaxConnections: 5}},
+				RSSKB:               1200,
+				LingeringContainers: 1,
+				Tasks:               taskCounts{Completed: 3},
+			},
+			{
+				At:                  start.Add(2 * time.Minute),
+				Stats:               api.DebugStats{PGXPool: api.DebugPoolStats{Acquired: 1, Idle: 4, Total: 5, MaxConnections: 5}},
+				RSSKB:               1150,
+				LingeringContainers: 0,
+				Tasks:               taskCounts{Completed: 6},
+			},
+		},
+	}
+
+	summary := Analyze(report)
+	if summary.Failed() {
+		t.Fatalf("expected pass, got violations: %v", summary.Violations)
+	}
+	if summary.Completed != 6 {
+		t.Fatalf("completed = %d, want 6", summary.Completed)
+	}
+}
+
+func TestAnalyzeFailsOnRSSGrowth(t *testing.T) {
+	report := Report{
+		StartedAt:  time.Now().Add(-2 * time.Minute),
+		FinishedAt: time.Now(),
+		Submitted:  2,
+		Samples: []Sample{
+			{At: time.Now().Add(-2 * time.Minute), RSSKB: 1000},
+			{At: time.Now(), RSSKB: 2501},
+		},
+	}
+
+	summary := Analyze(report)
+	if !summary.Failed() {
+		t.Fatal("expected RSS growth to fail")
+	}
+}
+
+func TestAnalyzeFailsOnPoolSaturation(t *testing.T) {
+	report := Report{
+		StartedAt:  time.Now().Add(-3 * time.Minute),
+		FinishedAt: time.Now(),
+		Submitted:  3,
+		Samples: []Sample{
+			{Stats: api.DebugStats{PGXPool: api.DebugPoolStats{Acquired: 2, Idle: 0, MaxConnections: 2}}},
+			{Stats: api.DebugStats{PGXPool: api.DebugPoolStats{Acquired: 2, Idle: 0, MaxConnections: 2}}},
+			{Stats: api.DebugStats{PGXPool: api.DebugPoolStats{Acquired: 2, Idle: 0, MaxConnections: 2}}},
+		},
+	}
+
+	summary := Analyze(report)
+	if !summary.Failed() {
+		t.Fatal("expected pool saturation to fail")
+	}
+}
+
+func TestAnalyzeFailsOnContainerAccumulation(t *testing.T) {
+	report := Report{
+		StartedAt:  time.Now().Add(-3 * time.Minute),
+		FinishedAt: time.Now(),
+		Submitted:  3,
+		Samples: []Sample{
+			{LingeringContainers: 0, Tasks: taskCounts{Completed: 0}},
+			{LingeringContainers: 2, Tasks: taskCounts{Completed: 1}},
+			{LingeringContainers: 4, Tasks: taskCounts{Completed: 2}},
+		},
+	}
+
+	summary := Analyze(report)
+	if !summary.Failed() {
+		t.Fatal("expected container accumulation to fail")
+	}
+}

--- a/test/soak/client.go
+++ b/test/soak/client.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/backflow-labs/backflow/internal/api"
+)
+
+const (
+	fakeAgentImage    = "backflow-fake-agent:test"
+	sampleInterval    = 60 * time.Second
+	defaultDuration   = time.Hour
+	shortDuration     = 12 * time.Minute
+	drainGrace        = 10 * time.Minute
+	taskSubmitTimeout = 10 * time.Second
+)
+
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func newClient(baseURL string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		http:    &http.Client{Timeout: taskSubmitTimeout},
+	}
+}
+
+func (c *Client) CreateTask(ctx context.Context, seq int) (string, error) {
+	body, err := json.Marshal(map[string]any{
+		"prompt":            fmt.Sprintf("soak task %d", seq),
+		"create_pr":         false,
+		"self_review":       false,
+		"save_agent_output": false,
+		"env_vars": map[string]string{
+			"FAKE_OUTCOME": "success",
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v1/tasks", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("create task: status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var env struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return "", err
+	}
+	if env.Error != "" {
+		return "", fmt.Errorf("create task: %s", env.Error)
+	}
+	if env.Data.ID == "" {
+		return "", fmt.Errorf("create task: empty task id")
+	}
+	return env.Data.ID, nil
+}
+
+func (c *Client) GetTask(ctx context.Context, id string) (taskState, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v1/tasks/"+id, nil)
+	if err != nil {
+		return taskState{}, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return taskState{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return taskState{}, fmt.Errorf("get task %s: status %d: %s", id, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var env struct {
+		Data  taskState `json:"data"`
+		Error string    `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return taskState{}, err
+	}
+	if env.Error != "" {
+		return taskState{}, fmt.Errorf("get task %s: %s", id, env.Error)
+	}
+	return env.Data, nil
+}
+
+func (c *Client) DebugStats(ctx context.Context) (api.DebugStats, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/debug/stats", nil)
+	if err != nil {
+		return api.DebugStats{}, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return api.DebugStats{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return api.DebugStats{}, fmt.Errorf("debug stats: status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var env struct {
+		Data  api.DebugStats `json:"data"`
+		Error string         `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return api.DebugStats{}, err
+	}
+	if env.Error != "" {
+		return api.DebugStats{}, fmt.Errorf("debug stats: %s", env.Error)
+	}
+	return env.Data, nil
+}
+
+type taskState struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+type taskCounts struct {
+	Pending      int
+	Provisioning int
+	Running      int
+	Completed    int
+	Failed       int
+	Interrupted  int
+	Cancelled    int
+	Recovering   int
+}
+
+func (c taskCounts) nonTerminal() int {
+	return c.Pending + c.Provisioning + c.Running + c.Interrupted + c.Recovering
+}
+
+func (c taskCounts) total() int {
+	return c.Pending + c.Provisioning + c.Running + c.Completed + c.Failed + c.Interrupted + c.Cancelled + c.Recovering
+}
+
+func sampleTaskCounts(ctx context.Context, client *Client, ids []string) (taskCounts, error) {
+	var counts taskCounts
+	for _, id := range ids {
+		task, err := client.GetTask(ctx, id)
+		if err != nil {
+			return taskCounts{}, err
+		}
+		switch task.Status {
+		case "pending":
+			counts.Pending++
+		case "provisioning":
+			counts.Provisioning++
+		case "running":
+			counts.Running++
+		case "completed":
+			counts.Completed++
+		case "failed":
+			counts.Failed++
+		case "interrupted":
+			counts.Interrupted++
+		case "cancelled":
+			counts.Cancelled++
+		case "recovering":
+			counts.Recovering++
+		default:
+			return taskCounts{}, fmt.Errorf("task %s: unknown status %q", id, task.Status)
+		}
+	}
+	return counts, nil
+}
+
+func discoverPID(apiURL string) (int, error) {
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		return 0, err
+	}
+	port := u.Port()
+	if port == "" {
+		return 0, fmt.Errorf("api-url %q must include a port", apiURL)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "lsof", "-ti", "tcp:"+port, "-sTCP:LISTEN").Output()
+	if err != nil {
+		return 0, fmt.Errorf("discover backflow pid for port %s: %w", port, err)
+	}
+
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return 0, fmt.Errorf("discover backflow pid for port %s: no listener found", port)
+	}
+
+	pid, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, fmt.Errorf("parse backflow pid %q: %w", fields[0], err)
+	}
+	return pid, nil
+}
+
+func readRSSKB(pid int) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "ps", "-o", "rss=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, fmt.Errorf("read rss for pid %d: %w", pid, err)
+	}
+
+	value := strings.TrimSpace(string(out))
+	if value == "" {
+		return 0, fmt.Errorf("read rss for pid %d: empty output", pid)
+	}
+
+	rss, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse rss %q for pid %d: %w", value, pid, err)
+	}
+	return rss, nil
+}
+
+func countLingeringContainers() (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "docker", "ps", "-a", "--filter", "ancestor="+fakeAgentImage, "--format", "{{.ID}}").Output()
+	if err != nil {
+		return 0, fmt.Errorf("count lingering containers: %w", err)
+	}
+
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return 0, nil
+	}
+	return len(strings.Split(trimmed, "\n")), nil
+}

--- a/test/soak/main.go
+++ b/test/soak/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "os"
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}

--- a/test/soak/run.go
+++ b/test/soak/run.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+type config struct {
+	apiURL       string
+	duration     time.Duration
+	short        bool
+	taskInterval time.Duration
+}
+
+func parseConfig(args []string) (config, error) {
+	fs := flag.NewFlagSet("soak", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var cfg config
+	fs.StringVar(&cfg.apiURL, "api-url", "http://localhost:8080", "Backflow API base URL")
+	fs.DurationVar(&cfg.duration, "duration", defaultDuration, "total soak duration")
+	fs.BoolVar(&cfg.short, "short", false, "run a short soak window")
+	fs.DurationVar(&cfg.taskInterval, "task-interval", 30*time.Second, "interval between task submissions")
+
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if cfg.short {
+		cfg.duration = shortDuration
+	}
+	if cfg.apiURL == "" {
+		return config{}, fmt.Errorf("--api-url is required")
+	}
+	if cfg.taskInterval <= 0 {
+		return config{}, fmt.Errorf("--task-interval must be positive")
+	}
+	return cfg, nil
+}
+
+func run(args []string) int {
+	cfg, err := parseConfig(args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	report, err := execute(cfg)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	summary := Analyze(*report)
+	fmt.Print(summary.String())
+	if summary.Failed() {
+		return 1
+	}
+	return 0
+}
+
+func execute(cfg config) (*Report, error) {
+	pid, err := discoverPID(cfg.apiURL)
+	if err != nil {
+		return nil, err
+	}
+
+	client := newClient(cfg.apiURL)
+	startedAt := time.Now().UTC()
+	report := &Report{StartedAt: startedAt}
+
+	initial, err := collectSample(context.Background(), client, pid, nil)
+	if err != nil {
+		return nil, err
+	}
+	report.Samples = append(report.Samples, initial)
+
+	runCtx, cancel := context.WithTimeout(context.Background(), cfg.duration+drainGrace)
+	defer cancel()
+
+	var (
+		mu      sync.Mutex
+		taskIDs []string
+		wg      sync.WaitGroup
+		runErr  error
+	)
+
+	setErr := func(err error) {
+		if err == nil {
+			return
+		}
+		mu.Lock()
+		if runErr == nil {
+			runErr = err
+			cancel()
+		}
+		mu.Unlock()
+	}
+
+	snapshotIDs := func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		ids := make([]string, len(taskIDs))
+		copy(ids, taskIDs)
+		return ids
+	}
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(cfg.taskInterval)
+		defer ticker.Stop()
+		deadline := startedAt.Add(cfg.duration)
+		seq := 0
+
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+			case <-ticker.C:
+				if time.Now().After(deadline) {
+					return
+				}
+				seq++
+				id, err := client.CreateTask(runCtx, seq)
+				if err != nil {
+					setErr(fmt.Errorf("create task %d: %w", seq, err))
+					return
+				}
+				mu.Lock()
+				taskIDs = append(taskIDs, id)
+				mu.Unlock()
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(sampleInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+			case <-ticker.C:
+				sample, err := collectSample(runCtx, client, pid, snapshotIDs())
+				if err != nil {
+					setErr(fmt.Errorf("collect sample: %w", err))
+					return
+				}
+				mu.Lock()
+				report.Samples = append(report.Samples, sample)
+				mu.Unlock()
+			}
+		}
+	}()
+
+	wg.Wait()
+	mu.Lock()
+	err = runErr
+	idsCopy := make([]string, len(taskIDs))
+	copy(idsCopy, taskIDs)
+	mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+
+	finalCtx, cancelFinal := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelFinal()
+	final, err := collectSample(finalCtx, client, pid, idsCopy)
+	if err != nil {
+		return nil, err
+	}
+	report.Samples = append(report.Samples, final)
+	report.FinishedAt = time.Now().UTC()
+	report.Submitted = len(idsCopy)
+	return report, nil
+}
+
+func collectSample(ctx context.Context, client *Client, pid int, ids []string) (Sample, error) {
+	stats, err := client.DebugStats(ctx)
+	if err != nil {
+		return Sample{}, err
+	}
+
+	rss, err := readRSSKB(pid)
+	if err != nil {
+		return Sample{}, err
+	}
+
+	containers, err := countLingeringContainers()
+	if err != nil {
+		return Sample{}, err
+	}
+
+	tasks, err := sampleTaskCounts(ctx, client, ids)
+	if err != nil {
+		return Sample{}, err
+	}
+
+	return Sample{
+		At:                  time.Now().UTC(),
+		Stats:               stats,
+		RSSKB:               rss,
+		LingeringContainers: containers,
+		Tasks:               tasks,
+	}, nil
+}


### PR DESCRIPTION
Implements issue #146: adds /debug/stats for operational monitoring and a standalone soak runner under test/soak that exercises Backflow against the fake agent.