### PR TITLE
Verify review posted to PR before reporting success

### DIFF
--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -273,6 +273,22 @@ You MUST post your review as a comment on the PR using the gh CLI. Do not just p
     if [ $CLAUDE_EXIT -eq 0 ]; then
         COMPLETE=true
         echo "==> PR review completed successfully"
+
+        # Verify the review was actually posted to the PR
+        echo "==> Verifying review was posted to PR..."
+        START_ISO=$(date -u -d "@$START_TIME" +%Y-%m-%dT%H:%M:%SZ)
+        REVIEWS_AFTER=$(gh pr view "$PR_REF" --json reviews \
+            --jq '[.reviews[] | select(.submittedAt > "'"$START_ISO"'")] | length' 2>/dev/null || echo "0")
+        COMMENTS_AFTER=$(gh pr view "$PR_REF" --json comments \
+            --jq '[.comments[] | select(.createdAt > "'"$START_ISO"'")] | length' 2>/dev/null || echo "0")
+        if [ "$((REVIEWS_AFTER + COMMENTS_AFTER))" -eq 0 ]; then
+            COMPLETE=false
+            CLAUDE_EXIT=1
+            ERROR_MSG="Review completed but was not posted to the PR. Check that the GitHub token has permission to write pull request reviews."
+            echo "==> WARNING: ${ERROR_MSG}"
+        else
+            echo "==> Verified: review posted (${REVIEWS_AFTER} reviews, ${COMMENTS_AFTER} comments since task start)"
+        fi
     else
         ERROR_MSG=$(echo "$CLAUDE_OUTPUT" | tail -5)
         echo "==> PR review failed (exit code: ${CLAUDE_EXIT})"


### PR DESCRIPTION
## Summary

- After a review task's agent exits successfully, verify via `gh pr view` that a review or comment was actually posted to the PR since the task started
- If no review/comment found, mark the task as **failed** with error: *"Review completed but was not posted to the PR. Check that the GitHub token has permission to write pull request reviews."*
- If found, log confirmation with counts

**Root cause**: Task `bf_01KN7YV6BZSV546V6G5RTS0QS0` completed a review but `gh pr review` failed with a token permission error. The agent fell back to printing the review as text, exited 0, and Backflow reported success — with no indication the review was never posted.

## Test plan

- [x] Build agent image: `make docker-agent-build-local`
- [x] Deploy to dev and submit a review task against a PR
- [x] With insufficient token permissions: task should fail with the new error message
- [x] With correct token permissions: task should complete with "Verified: review posted" log line