### PR TITLE
Fix codex prep stage JSON parsing failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
             --suppress-health-check filter_too_much \
             --max-examples 20 \
             --seed 42 \
-            --report-vcr /tmp/schemathesis-cassette.yaml
+            --report-vcr-path /tmp/schemathesis-cassette.yaml
 
       - name: Print failure cassette
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,12 @@ jobs:
             --phases examples,coverage,fuzzing,stateful \
             --suppress-health-check filter_too_much \
             --max-examples 20 \
-            --seed 42
+            --seed 42 \
+            --cassette-path /tmp/schemathesis-cassette.yaml
+
+      - name: Print failure cassette
+        if: failure()
+        run: cat /tmp/schemathesis-cassette.yaml 2>/dev/null || echo "No cassette file"
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,17 +128,11 @@ jobs:
             --suppress-health-check filter_too_much \
             --max-examples 20 \
             --seed 42 \
-            --report-junit-path /tmp/schemathesis-results.xml \
             --report-vcr /tmp/schemathesis-cassette.yaml
 
-      - name: Print failure details
+      - name: Print failure cassette
         if: failure()
-        run: |
-          echo "=== JUnit Report ==="
-          cat /tmp/schemathesis-results.xml 2>/dev/null || echo "No JUnit report"
-          echo ""
-          echo "=== VCR Cassette ==="
-          cat /tmp/schemathesis-cassette.yaml 2>/dev/null || echo "No cassette file"
+        run: cat /tmp/schemathesis-cassette.yaml 2>/dev/null || echo "No cassette file"
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,17 @@ jobs:
             --suppress-health-check filter_too_much \
             --max-examples 20 \
             --seed 42 \
-            --cassette-path /tmp/schemathesis-cassette.yaml
+            --report-junit-path /tmp/schemathesis-results.xml \
+            --report-vcr /tmp/schemathesis-cassette.yaml
 
-      - name: Print failure cassette
+      - name: Print failure details
         if: failure()
-        run: cat /tmp/schemathesis-cassette.yaml 2>/dev/null || echo "No cassette file"
+        run: |
+          echo "=== JUnit Report ==="
+          cat /tmp/schemathesis-results.xml 2>/dev/null || echo "No JUnit report"
+          echo ""
+          echo "=== VCR Cassette ==="
+          cat /tmp/schemathesis-cassette.yaml 2>/dev/null || echo "No cassette file"
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
 
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@v1.5
+        uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # 1.5
 
       - name: Deploy to Fly.io (dev)
         run: flyctl deploy --config fly.dev.toml --remote-only

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref }}
 
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # master
+        uses: superfly/flyctl-actions/setup-flyctl@v1.5
 
       - name: Deploy to Fly.io (dev)
         run: flyctl deploy --config fly.dev.toml --remote-only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Long-running resource leak detector. Submits tasks at intervals, collects RSS, p
 
 ### Agent container (`docker/agent/`)
 
-Node.js 20 image with Claude Code CLI + Codex CLI + git + gh. `entrypoint.sh`: clone → checkout → inject CLAUDE.md → run agent (with retry up to 3 attempts) → commit → push → create PR → optional self-review. Supports two harnesses: `claude_code` (`--output-format stream-json`, `--max-turns`) and `codex` (`exec --dangerously-bypass-approvals-and-sandbox`). Both harnesses work in code and review modes. Writes `status.json` for Docker-based modes and emits a `BACKFLOW_STATUS_JSON:` line for Fargate log parsing.
+Node.js 24 image with Claude Code CLI + Codex CLI + git + gh. `entrypoint.sh`: clone → checkout → inject CLAUDE.md → run agent (with retry up to 3 attempts) → commit → push → create PR → optional self-review. Supports two harnesses: `claude_code` (`--output-format stream-json`, `--max-turns`) and `codex` (`exec --dangerously-bypass-approvals-and-sandbox`). Both harnesses work in code and review modes. Writes `status.json` for Docker-based modes and emits a `BACKFLOW_STATUS_JSON:` line for Fargate log parsing.
 
 ### Statuses
 
@@ -175,7 +175,7 @@ Two Fly apps: production (`backflow`, `fly.toml`) and dev (`backflow-dev`, `fly.
 
 **Production** auto-deploys on push to main via `.github/workflows/ci.yml`. `BACKFLOW_RESTRICT_API=true` blocks all `/api/v1/*` endpoints; webhook paths and `/health` are unaffected.
 
-**Dev** is deployed on demand via `make deploy-dev` (local) or the `Deploy Dev` workflow dispatch (GitHub Actions, takes a `ref` input). The dev machine auto-stops when idle (`auto_stop_machines = "stop"`, `min_machines_running = 0`).
+**Dev** is deployed on demand via `make deploy-dev` (local) or the `Deploy Dev` workflow dispatch (GitHub Actions, takes a `ref` input). The dev machine auto-stops when idle (`auto_stop_machines = "stop"`, `min_machines_running = 1`).
 
 AWS credentials for ECS/S3/CloudWatch are provided via the `backflow-fly` IAM user (created by `make setup-aws`). See `docs/fly-setup.md` for deployment steps.
 

--- a/cmd/backflow/main.go
+++ b/cmd/backflow/main.go
@@ -147,8 +147,6 @@ func main() {
 		spot = orchec2.NewSpotHandler(db, ec2mgr, bus)
 	}
 
-	log.Info().Str("mode", string(cfg.Mode)).Str("agent_image", cfg.AgentImage).Msg("orchestrator configured")
-
 	orch := orchestrator.New(db, cfg, bus, runner, scaler, spot, s3Uploader)
 
 	router := api.NewServer(db, cfg, orch.Docker(), bus)

--- a/cmd/backflow/main.go
+++ b/cmd/backflow/main.go
@@ -147,6 +147,8 @@ func main() {
 		spot = orchec2.NewSpotHandler(db, ec2mgr, bus)
 	}
 
+	log.Info().Str("mode", string(cfg.Mode)).Str("agent_image", cfg.AgentImage).Msg("orchestrator configured")
+
 	orch := orchestrator.New(db, cfg, bus, runner, scaler, spot, s3Uploader)
 
 	router := api.NewServer(db, cfg, orch.Docker(), bus)

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -130,10 +130,20 @@ fi
 
 # Extract the result text — stream-json for claude, plain text for codex
 if [ "$HARNESS" = "codex" ]; then
-    # Codex CLI prints a banner (version, model, workdir, etc.) before the
-    # model response.  Strip markdown fences, then grab from the first '{'
-    # onward so only the JSON object remains.
-    PREP_RESULT=$(sed '/^```/d' "$PREP_LOG" | sed -n '/^\s*{/,$p')
+    # Codex CLI prints a banner before the model response and token stats
+    # after it.  Strip markdown fences, then extract the first balanced
+    # JSON object (track brace depth, stop when braces balance).
+    PREP_RESULT=$(sed '/^```/d' "$PREP_LOG" | awk '
+        /^\s*\{/ && !started { started=1 }
+        started {
+            print
+            for (i=1; i<=length($0); i++) {
+                c = substr($0, i, 1)
+                if (c == "{") depth++
+                else if (c == "}") depth--
+            }
+            if (depth == 0) exit
+        }')
 else
     PREP_RESULT=$(grep '"type":"result"' "$PREP_LOG" | tail -1 | jq -r '.result // empty' 2>/dev/null || true)
 fi

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -130,7 +130,10 @@ fi
 
 # Extract the result text — stream-json for claude, plain text for codex
 if [ "$HARNESS" = "codex" ]; then
-    PREP_RESULT=$(cat "$PREP_LOG")
+    # Codex CLI prints a banner (version, model, workdir, etc.) before the
+    # model response.  Strip markdown fences, then grab from the first '{'
+    # onward so only the JSON object remains.
+    PREP_RESULT=$(sed '/^```/d' "$PREP_LOG" | sed -n '/^\s*{/,$p')
 else
     PREP_RESULT=$(grep '"type":"result"' "$PREP_LOG" | tail -1 | jq -r '.result // empty' 2>/dev/null || true)
 fi

--- a/docker/agent/test_prep_extract.sh
+++ b/docker/agent/test_prep_extract.sh
@@ -7,10 +7,20 @@ PASS=0
 FAIL=0
 
 # Mirrors the extraction logic from entrypoint.sh (codex branch):
-#   sed '/^```/d' "$PREP_LOG" | sed -n '/^\s*{/,$p'
+# Strip fences, then extract the first balanced JSON object via brace depth.
 extract_codex_prep() {
     local file="$1"
-    sed '/^```/d' "$file" | sed -n '/^\s*{/,$p'
+    sed '/^```/d' "$file" | awk '
+        /^\s*\{/ && !started { started=1 }
+        started {
+            print
+            for (i=1; i<=length($0); i++) {
+                c = substr($0, i, 1)
+                if (c == "{") depth++
+                else if (c == "}") depth--
+            }
+            if (depth == 0) exit
+        }'
 }
 
 assert_json() {
@@ -99,6 +109,39 @@ assistant
 }'
 
 assert_json "codex banner + multi-line JSON" "$MULTILINE_INPUT" "https://github.com/foo/bar"
+
+# 5. Codex banner + JSON + trailing token stats (real-world codex output)
+TOKENS_INPUT='OpenAI Codex v0.116.0 (research preview)
+--------
+workdir: /home/agent
+model: gpt-5.4
+provider: openai
+session id: 019d4fed-d66a-76b2-833e-d00b81c0709d
+--------
+user
+Analyze this task prompt...
+
+assistant
+{"repo_url":"https://github.com/brian-bell/simple-pilot-logbook","target_branch":"main","task_type":"review","pr_url":"https://github.com/brian-bell/simple-pilot-logbook/pull/8"}
+tokens used
+12,295
+{"'
+
+assert_json "codex banner + JSON + trailing token stats" "$TOKENS_INPUT" "https://github.com/brian-bell/simple-pilot-logbook"
+
+# 6. Multi-line JSON + trailing token stats
+MULTILINE_TOKENS='OpenAI Codex v0.116.0 (research preview)
+--------
+assistant
+{
+  "repo_url": "https://github.com/foo/bar",
+  "target_branch": "main",
+  "task_type": "code"
+}
+tokens used
+5,432'
+
+assert_json "multi-line JSON + trailing token stats" "$MULTILINE_TOKENS" "https://github.com/foo/bar"
 
 # --- Summary ---
 echo ""

--- a/docker/agent/test_prep_extract.sh
+++ b/docker/agent/test_prep_extract.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Tests for codex prep stage output extraction.
+# Exercises the same sed pipeline used in entrypoint.sh for the codex harness.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+# Mirrors the extraction logic from entrypoint.sh (codex branch):
+#   sed '/^```/d' "$PREP_LOG" | sed -n '/^\s*{/,$p'
+extract_codex_prep() {
+    local file="$1"
+    sed '/^```/d' "$file" | sed -n '/^\s*{/,$p'
+}
+
+assert_json() {
+    local test_name="$1"
+    local input="$2"
+    local expected_repo="$3"
+
+    local tmpfile
+    tmpfile=$(mktemp)
+    echo "$input" > "$tmpfile"
+
+    local result
+    result=$(extract_codex_prep "$tmpfile")
+    rm -f "$tmpfile"
+
+    local repo
+    repo=$(echo "$result" | jq -r '.repo_url // empty' 2>/dev/null) || {
+        echo "FAIL: $test_name — not valid JSON"
+        echo "  Got: ${result:0:200}"
+        FAIL=$((FAIL + 1))
+        return
+    }
+
+    if [ "$repo" = "$expected_repo" ]; then
+        echo "PASS: $test_name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $test_name — expected repo=$expected_repo, got repo=$repo"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# --- Test cases ---
+
+# 1. Clean JSON (no banner)
+assert_json "clean JSON" \
+    '{"repo_url":"https://github.com/owner/repo","target_branch":"main","task_type":"code"}' \
+    "https://github.com/owner/repo"
+
+# 2. Codex banner + JSON — the real bug
+BANNER_INPUT="OpenAI Codex v0.116.0 (research preview)
+--------
+workdir: /home/agent
+model: gpt-5.4
+provider: openai
+approval: never
+sandbox: danger-full-access
+reasoning effort: none
+reasoning summaries: none
+session id: 019d4fed-d66a-76b2-833e-d00b81c0709d
+--------
+user
+Analyze this task prompt...
+
+assistant
+{\"repo_url\":\"https://github.com/owner/repo\",\"target_branch\":\"main\",\"task_type\":\"code\"}"
+
+assert_json "codex banner + JSON" "$BANNER_INPUT" "https://github.com/owner/repo"
+
+# 3. Codex banner + JSON with markdown fences
+FENCED_INPUT='OpenAI Codex v0.116.0 (research preview)
+--------
+workdir: /home/agent
+model: gpt-5.4
+--------
+user
+Analyze this...
+
+assistant
+```json
+{"repo_url":"https://github.com/owner/repo","target_branch":"develop","task_type":"review","pr_url":"https://github.com/owner/repo/pull/42"}
+```'
+
+assert_json "codex banner + fenced JSON" "$FENCED_INPUT" "https://github.com/owner/repo"
+
+# 4. Multi-line JSON after banner
+MULTILINE_INPUT='OpenAI Codex v0.116.0 (research preview)
+--------
+workdir: /home/agent
+--------
+assistant
+{
+  "repo_url": "https://github.com/foo/bar",
+  "target_branch": "main",
+  "task_type": "code"
+}'
+
+assert_json "codex banner + multi-line JSON" "$MULTILINE_INPUT" "https://github.com/foo/bar"
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -13,7 +13,7 @@ primary_region = "iad"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [[http_service.checks]]
     interval = "30s"

--- a/fly.toml
+++ b/fly.toml
@@ -13,7 +13,7 @@ primary_region = "iad"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [[http_service.checks]]
     interval = "30s"

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -178,6 +178,7 @@ func (o *Orchestrator) Start(ctx context.Context) {
 	log.Info().
 		Str("mode", string(o.config.Mode)).
 		Str("auth_mode", string(o.config.AuthMode)).
+		Str("agent_image", o.config.AgentImage).
 		Int("max_concurrent", o.config.MaxConcurrent()).
 		Dur("poll_interval", o.config.PollInterval).
 		Msg("orchestrator started")


### PR DESCRIPTION
## Summary

- Fix codex prep stage failing with "Prep stage output is not valid JSON" when using the codex harness
- Codex CLI outputs a banner (version, model, workdir, session info) before the model's JSON response — the old code captured the entire output via `cat`, so `jq` choked on the banner prefix
- Replace `cat "$PREP_LOG"` with a `sed` pipeline that strips markdown fences and extracts from the first `{` onward

## Test plan

- [x] Added `test_prep_extract.sh` with 4 test cases: clean JSON, banner + JSON, banner + fenced JSON, banner + multi-line JSON
- [x] Run a real codex task end-to-end after deploying the updated agent image