### PR TITLE
Add explicit --config fly.toml to production deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,7 @@ jobs:
             --suppress-health-check filter_too_much \
             --max-examples 20 \
             --seed 42 \
-            --report-vcr-path /tmp/schemathesis-cassette.yaml
-
-      - name: Print failure cassette
-        if: failure()
-        run: cat /tmp/schemathesis-cassette.yaml 2>/dev/null || echo "No cassette file"
+            --output-mode verbose
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,6 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # master
 
       - name: Deploy to Fly.io
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --config fly.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,17 @@ jobs:
             --suppress-health-check filter_too_much \
             --max-examples 20 \
             --seed 42 \
-            --output-mode verbose
+            --output-truncate false \
+            --report-vcr-path /tmp/schemathesis-cassette.yaml
+
+      - name: Print failure cassette
+        if: failure()
+        run: |
+          if [ -f /tmp/schemathesis-cassette.yaml ]; then
+            grep -B 10 "FAILURE" /tmp/schemathesis-cassette.yaml || cat /tmp/schemathesis-cassette.yaml | tail -200
+          else
+            echo "No cassette file"
+          fi
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The production deploy job relied on flyctl auto-detecting `fly.toml`, which meant config changes (like `min_machines_running`) were not being applied
- Add `--config fly.toml` to match the dev workflow pattern (`--config fly.dev.toml`)

## Follow-up
After merging, trigger the `Deploy Dev` workflow dispatch to apply the pending `fly.dev.toml` changes to backflow-dev.