### PR TITLE
Split CI into parallel static + test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  ci:
+  static:
     runs-on: ubuntu-latest
 
     steps:
@@ -31,6 +31,19 @@ jobs:
 
       - name: Lint
         run: go vet ./...
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
 
       - name: Build
         run: go build -trimpath -o bin/backflow ./cmd/backflow
@@ -142,7 +155,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [ci, fuzz, blackbox]
+    needs: [static, test, fuzz, blackbox]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     concurrency:
       group: fly-deploy


### PR DESCRIPTION
## Why

On the latest green PR run, \`ci\` was the long pole at **3m 19s**. Inside it:

| Step | Time | Share |
|---|---|---|
| \`go test ... -race\` | 1m 56s | 58% |
| \`go vet ./...\` | 1m 5s | 33% |
| Everything else | ~18s | 9% |

\`go vet\` recompiles the whole tree independently of tests, so the two stages don't share work — they just serialize. Running them as sibling jobs drops the PR wall clock to ~\`max(test, static)\` ≈ **2m** and saves roughly a minute per PR.

## What changed

Split the one \`ci\` job into two:

- **\`static\`** — checkout + setup-go + \`gofmt\` check + \`go vet ./...\`
- **\`test\`** — checkout + setup-go + build + \`go test -race\`

\`blackbox\` and \`fuzz\` are unchanged; \`deploy\` now waits on \`[static, test, fuzz, blackbox]\` instead of \`[ci, fuzz, blackbox]\`.

Both new jobs share the Go module + build cache via \`actions/setup-go@v6\`'s \`cache: true\`, so the second job's setup is effectively free after the first populates the cache.

## Branch-protection update needed

If \`ci\` was a required status check in repo Settings → Branches → Branch protection, swap it for the two new names (\`static\` and \`test\`). Do this **before** merge so the rule doesn't block on a check that no longer exists.

## Test plan

- [x] YAML validates (\`python3 -c 'import yaml; yaml.safe_load(open(...))'\`).
- [ ] This PR's own CI run shows \`static\` and \`test\` running in parallel and completing in roughly the time of the slower one.
- [ ] After merge, a follow-up PR's CI should run in noticeably less wall-clock time than before.