### PR TITLE
Add per-task agent_image field and reading-mode config

### DIFF
--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -25,12 +25,6 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-type capturingEmitter struct {
-	events []notify.Event
-}
-
-func (c *capturingEmitter) Emit(e notify.Event) { c.events = append(c.events, e) }
-
 var (
 	sharedConnStr string
 	truncatePool  *pgxpool.Pool

--- a/internal/api/task_actions_test.go
+++ b/internal/api/task_actions_test.go
@@ -47,7 +47,7 @@ func TestCancelTask_RunningTask(t *testing.T) {
 	s := &taskActionStore{
 		task: &models.Task{ID: "bf_1", Status: models.TaskStatusRunning},
 	}
-	bus := &capturingEmitter2{}
+	bus := &capturingEmitter{}
 
 	err := CancelTask(context.Background(), "bf_1", s, bus)
 	if err != nil {
@@ -65,7 +65,7 @@ func TestCancelTask_ProvisioningTask(t *testing.T) {
 	s := &taskActionStore{
 		task: &models.Task{ID: "bf_1", Status: models.TaskStatusProvisioning},
 	}
-	bus := &capturingEmitter2{}
+	bus := &capturingEmitter{}
 
 	err := CancelTask(context.Background(), "bf_1", s, bus)
 	if err != nil {
@@ -80,7 +80,7 @@ func TestCancelTask_PendingTask(t *testing.T) {
 	s := &taskActionStore{
 		task: &models.Task{ID: "bf_1", Status: models.TaskStatusPending},
 	}
-	bus := &capturingEmitter2{}
+	bus := &capturingEmitter{}
 
 	err := CancelTask(context.Background(), "bf_1", s, bus)
 	if err != nil {
@@ -95,7 +95,7 @@ func TestCancelTask_RecoveringTask(t *testing.T) {
 	s := &taskActionStore{
 		task: &models.Task{ID: "bf_1", Status: models.TaskStatusRecovering},
 	}
-	bus := &capturingEmitter2{}
+	bus := &capturingEmitter{}
 
 	err := CancelTask(context.Background(), "bf_1", s, bus)
 	if err != nil {
@@ -110,7 +110,7 @@ func TestCancelTask_CompletedTask_ReturnsError(t *testing.T) {
 	s := &taskActionStore{
 		task: &models.Task{ID: "bf_1", Status: models.TaskStatusCompleted},
 	}
-	bus := &capturingEmitter2{}
+	bus := &capturingEmitter{}
 
 	err := CancelTask(context.Background(), "bf_1", s, bus)
 	if err == nil {
@@ -126,7 +126,7 @@ func TestCancelTask_CompletedTask_ReturnsError(t *testing.T) {
 
 func TestCancelTask_NotFound(t *testing.T) {
 	s := &taskActionStore{getErr: store.ErrNotFound}
-	bus := &capturingEmitter2{}
+	bus := &capturingEmitter{}
 
 	err := CancelTask(context.Background(), "bf_missing", s, bus)
 	if err == nil {
@@ -139,7 +139,7 @@ func TestCancelTask_StoreError(t *testing.T) {
 		task:      &models.Task{ID: "bf_1", Status: models.TaskStatusRunning},
 		cancelErr: fmt.Errorf("db error"),
 	}
-	bus := &capturingEmitter2{}
+	bus := &capturingEmitter{}
 
 	err := CancelTask(context.Background(), "bf_1", s, bus)
 	if err == nil {

--- a/internal/api/task_creator.go
+++ b/internal/api/task_creator.go
@@ -66,3 +66,48 @@ func NewTask(ctx context.Context, req *models.CreateTaskRequest, s store.Store, 
 
 	return task, nil
 }
+
+// NewReadTask validates the request, applies read-mode defaults (reader image
+// and tighter budget/runtime/turn caps), persists the task, and emits a
+// task.created event. PR-related fields from the request are ignored — read
+// tasks never open PRs.
+func NewReadTask(ctx context.Context, req *models.CreateTaskRequest, s store.Store, cfg *config.Config, bus notify.Emitter) (*models.Task, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+
+	task := &models.Task{
+		ID:            "bf_" + ulid.Make().String(),
+		Status:        models.TaskStatusPending,
+		TaskMode:      models.TaskModeRead,
+		Harness:       models.Harness(req.Harness),
+		Prompt:        req.Prompt,
+		Context:       req.Context,
+		Model:         req.Model,
+		Effort:        req.Effort,
+		MaxBudgetUSD:  req.MaxBudgetUSD,
+		MaxRuntimeSec: req.MaxRuntimeSec,
+		MaxTurns:      req.MaxTurns,
+		AllowedTools:  req.AllowedTools,
+		ClaudeMD:      req.ClaudeMD,
+		EnvVars:       req.EnvVars,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	cfg.TaskDefaults(models.TaskModeRead).Apply(task, &config.BoolOverrides{
+		SaveAgentOutput: req.SaveAgentOutput,
+	})
+
+	if err := s.CreateTask(ctx, task); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrStoreFailure, err)
+	}
+
+	if bus != nil {
+		bus.Emit(notify.NewEvent(notify.EventTaskCreated, task))
+	}
+
+	return task, nil
+}

--- a/internal/api/task_creator.go
+++ b/internal/api/task_creator.go
@@ -69,8 +69,14 @@ func NewTask(ctx context.Context, req *models.CreateTaskRequest, s store.Store, 
 
 // NewReadTask validates the request, applies read-mode defaults (reader image
 // and tighter budget/runtime/turn caps), persists the task, and emits a
-// task.created event. PR-related fields from the request are ignored — read
-// tasks never open PRs.
+// task.created event.
+//
+// Honored request fields: Prompt, Context, Model, Harness, Effort,
+// MaxBudgetUSD, MaxRuntimeSec, MaxTurns, AllowedTools, ClaudeMD, EnvVars,
+// SaveAgentOutput.
+//
+// Ignored request fields: PRTitle, PRBody, CreatePR, SelfReview — read tasks
+// never clone repos or open PRs, so these fields have no effect.
 func NewReadTask(ctx context.Context, req *models.CreateTaskRequest, s store.Store, cfg *config.Config, bus notify.Emitter) (*models.Task, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err

--- a/internal/api/task_creator_test.go
+++ b/internal/api/task_creator_test.go
@@ -71,3 +71,100 @@ type capturingEmitter2 struct {
 }
 
 func (c *capturingEmitter2) Emit(e notify.Event) { c.events = append(c.events, e) }
+
+// readTestConfig returns a config suitable for testing NewReadTask: populates
+// the reader image and read-mode caps that TaskDefaults("read") reads from.
+func readTestConfig() *config.Config {
+	return &config.Config{
+		AgentImage:            "backflow-agent",
+		ReaderImage:           "backflow-reader:v1",
+		DefaultHarness:        "claude_code",
+		DefaultClaudeModel:    "claude-sonnet-4-6",
+		DefaultCodexModel:     "gpt-5.4",
+		DefaultEffort:         "medium",
+		DefaultReadMaxBudget:  0.5,
+		DefaultReadMaxRuntime: 300_000_000_000, // 300s in ns
+		DefaultReadMaxTurns:   20,
+		DefaultSaveOutput:     true,
+	}
+}
+
+func TestNewReadTask_SetsReadModeAndReaderImage(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{}
+	req := &models.CreateTaskRequest{Prompt: "https://example.com/post"}
+
+	task, err := NewReadTask(context.Background(), req, s, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewReadTask: %v", err)
+	}
+	if task.TaskMode != models.TaskModeRead {
+		t.Errorf("TaskMode = %q, want %q", task.TaskMode, models.TaskModeRead)
+	}
+	if task.AgentImage != "backflow-reader:v1" {
+		t.Errorf("AgentImage = %q, want %q", task.AgentImage, "backflow-reader:v1")
+	}
+	if task.CreatePR {
+		t.Error("CreatePR = true, want false for read mode")
+	}
+	if task.Status != models.TaskStatusPending {
+		t.Errorf("Status = %q, want pending", task.Status)
+	}
+	if task.MaxBudgetUSD != 0.5 {
+		t.Errorf("MaxBudgetUSD = %v, want 0.5 (read cap)", task.MaxBudgetUSD)
+	}
+	if task.MaxRuntimeSec != 300 {
+		t.Errorf("MaxRuntimeSec = %d, want 300 (read cap)", task.MaxRuntimeSec)
+	}
+	if task.MaxTurns != 20 {
+		t.Errorf("MaxTurns = %d, want 20 (read cap)", task.MaxTurns)
+	}
+	if len(task.ID) < 4 || task.ID[:3] != "bf_" {
+		t.Errorf("ID = %q, want bf_ prefix", task.ID)
+	}
+}
+
+func TestNewReadTask_EmitsCreatedEvent(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{}
+	bus := &capturingEmitter2{}
+	req := &models.CreateTaskRequest{Prompt: "https://example.com/post"}
+
+	if _, err := NewReadTask(context.Background(), req, s, cfg, bus); err != nil {
+		t.Fatalf("NewReadTask: %v", err)
+	}
+	if len(bus.events) != 1 {
+		t.Fatalf("events count = %d, want 1", len(bus.events))
+	}
+	if bus.events[0].Type != notify.EventTaskCreated {
+		t.Errorf("event type = %q, want %q", bus.events[0].Type, notify.EventTaskCreated)
+	}
+}
+
+func TestNewReadTask_StoreError_WrapsErrStoreFailure(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{createErr: fmt.Errorf("connection refused")}
+	req := &models.CreateTaskRequest{Prompt: "https://example.com/post"}
+
+	_, err := NewReadTask(context.Background(), req, s, cfg, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrStoreFailure) {
+		t.Errorf("error = %v, want errors.Is(err, ErrStoreFailure)", err)
+	}
+}
+
+func TestNewReadTask_ValidationError_NotStoreFailure(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{}
+	req := &models.CreateTaskRequest{Prompt: ""}
+
+	_, err := NewReadTask(context.Background(), req, s, cfg, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrStoreFailure) {
+		t.Errorf("validation error should not match ErrStoreFailure, got: %v", err)
+	}
+}

--- a/internal/api/task_creator_test.go
+++ b/internal/api/task_creator_test.go
@@ -66,11 +66,11 @@ func TestNewTask_ValidationError_NotStoreFailure(t *testing.T) {
 	}
 }
 
-type capturingEmitter2 struct {
+type capturingEmitter struct {
 	events []notify.Event
 }
 
-func (c *capturingEmitter2) Emit(e notify.Event) { c.events = append(c.events, e) }
+func (c *capturingEmitter) Emit(e notify.Event) { c.events = append(c.events, e) }
 
 // readTestConfig returns a config suitable for testing NewReadTask: populates
 // the reader image and read-mode caps that TaskDefaults("read") reads from.
@@ -127,7 +127,7 @@ func TestNewReadTask_SetsReadModeAndReaderImage(t *testing.T) {
 func TestNewReadTask_EmitsCreatedEvent(t *testing.T) {
 	cfg := readTestConfig()
 	s := &mockStore{}
-	bus := &capturingEmitter2{}
+	bus := &capturingEmitter{}
 	req := &models.CreateTaskRequest{Prompt: "https://example.com/post"}
 
 	if _, err := NewReadTask(context.Background(), req, s, cfg, bus); err != nil {
@@ -166,5 +166,38 @@ func TestNewReadTask_ValidationError_NotStoreFailure(t *testing.T) {
 	}
 	if errors.Is(err, ErrStoreFailure) {
 		t.Errorf("validation error should not match ErrStoreFailure, got: %v", err)
+	}
+}
+
+// TestNewReadTask_IgnoresPRFields pins the documented contract that read
+// tasks never open PRs. A future refactor must not silently start honoring
+// PRTitle, PRBody, CreatePR, or SelfReview.
+func TestNewReadTask_IgnoresPRFields(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{}
+	trueVal := true
+	req := &models.CreateTaskRequest{
+		Prompt:     "https://example.com/post",
+		PRTitle:    "ignored",
+		PRBody:     "ignored",
+		CreatePR:   &trueVal,
+		SelfReview: &trueVal,
+	}
+
+	task, err := NewReadTask(context.Background(), req, s, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewReadTask: %v", err)
+	}
+	if task.PRTitle != "" {
+		t.Errorf("PRTitle = %q, want empty (ignored for read mode)", task.PRTitle)
+	}
+	if task.PRBody != "" {
+		t.Errorf("PRBody = %q, want empty (ignored for read mode)", task.PRBody)
+	}
+	if task.CreatePR {
+		t.Error("CreatePR = true, want false (ignored for read mode)")
+	}
+	if task.SelfReview {
+		t.Error("SelfReview = true, want false (ignored for read mode)")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -279,6 +279,23 @@ func Load() (*Config, error) {
 		}
 	}
 
+	if c.ReaderImage != "" {
+		switch {
+		case c.DefaultReadMaxBudget <= 0:
+			return nil, fmt.Errorf("BACKFLOW_DEFAULT_READ_MAX_BUDGET must be > 0 when BACKFLOW_READER_IMAGE is set")
+		case c.DefaultReadMaxRuntime <= 0:
+			return nil, fmt.Errorf("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC must be > 0 when BACKFLOW_READER_IMAGE is set")
+		case c.DefaultReadMaxTurns <= 0:
+			return nil, fmt.Errorf("BACKFLOW_DEFAULT_READ_MAX_TURNS must be > 0 when BACKFLOW_READER_IMAGE is set")
+		case c.SupabaseURL == "":
+			return nil, fmt.Errorf("SUPABASE_URL is required when BACKFLOW_READER_IMAGE is set")
+		case c.SupabaseAnonKey == "":
+			return nil, fmt.Errorf("SUPABASE_ANON_KEY is required when BACKFLOW_READER_IMAGE is set")
+		case c.Mode == ModeFargate && c.ECSReaderTaskDefinition == "":
+			return nil, fmt.Errorf("BACKFLOW_ECS_READER_TASK_DEFINITION is required when BACKFLOW_READER_IMAGE is set in %s mode", ModeFargate)
+		}
+	}
+
 	return c, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,19 +31,20 @@ type Config struct {
 	OpenAIAPIKey    string
 
 	// AWS
-	AWSRegion         string
-	InstanceType      string
-	AMI               string
-	MaxInstances      int
-	ContainersPerInst int
-	LaunchTemplateID  string
-	ECSCluster        string
-	ECSTaskDefinition string
-	ECSSubnets        []string
-	ECSSecurityGroups []string
-	ECSLaunchType     string
-	ECSContainerName  string
-	ECSAssignPublicIP bool
+	AWSRegion               string
+	InstanceType            string
+	AMI                     string
+	MaxInstances            int
+	ContainersPerInst       int
+	LaunchTemplateID        string
+	ECSCluster              string
+	ECSTaskDefinition       string
+	ECSReaderTaskDefinition string
+	ECSSubnets              []string
+	ECSSecurityGroups       []string
+	ECSLaunchType           string
+	ECSContainerName        string
+	ECSAssignPublicIP       bool
 
 	// Container resources
 	ContainerCPUs  int
@@ -57,14 +58,22 @@ type Config struct {
 	MaxConcurrentTasks int
 
 	// Agent
-	AgentImage         string
-	DefaultHarness     string
-	DefaultClaudeModel string
-	DefaultCodexModel  string
-	DefaultEffort      string
-	DefaultMaxBudget   float64
-	DefaultMaxRuntime  time.Duration
-	DefaultMaxTurns    int
+	AgentImage            string
+	ReaderImage           string
+	DefaultHarness        string
+	DefaultClaudeModel    string
+	DefaultCodexModel     string
+	DefaultEffort         string
+	DefaultMaxBudget      float64
+	DefaultMaxRuntime     time.Duration
+	DefaultMaxTurns       int
+	DefaultReadMaxBudget  float64
+	DefaultReadMaxRuntime time.Duration
+	DefaultReadMaxTurns   int
+
+	// Supabase (passed through to reader containers)
+	SupabaseURL     string
+	SupabaseAnonKey string
 
 	// Boolean defaults
 	DefaultCreatePR   bool
@@ -133,54 +142,61 @@ func (c *Config) MaxConcurrent() int {
 
 func Load() (*Config, error) {
 	c := &Config{
-		Mode:                Mode(envOr("BACKFLOW_MODE", string(ModeEC2))),
-		ListenAddr:          envOr("BACKFLOW_LISTEN_ADDR", ":8080"),
-		APIKey:              os.Getenv("BACKFLOW_API_KEY"),
-		AnthropicAPIKey:     os.Getenv("ANTHROPIC_API_KEY"),
-		OpenAIAPIKey:        os.Getenv("OPENAI_API_KEY"),
-		AWSRegion:           envOr("AWS_REGION", "us-east-1"),
-		InstanceType:        envOr("BACKFLOW_INSTANCE_TYPE", "m7g.xlarge"),
-		AMI:                 os.Getenv("BACKFLOW_AMI"),
-		MaxInstances:        envInt("BACKFLOW_MAX_INSTANCES", 5),
-		ContainersPerInst:   envInt("BACKFLOW_CONTAINERS_PER_INSTANCE", 1),
-		ECSCluster:          os.Getenv("BACKFLOW_ECS_CLUSTER"),
-		ECSTaskDefinition:   os.Getenv("BACKFLOW_ECS_TASK_DEFINITION"),
-		ECSSubnets:          envCSV("BACKFLOW_ECS_SUBNETS"),
-		ECSSecurityGroups:   envCSV("BACKFLOW_ECS_SECURITY_GROUPS"),
-		ECSLaunchType:       strings.ToUpper(envOr("BACKFLOW_ECS_LAUNCH_TYPE", "FARGATE_SPOT")),
-		ECSContainerName:    envOr("BACKFLOW_ECS_CONTAINER_NAME", "backflow-agent"),
-		ECSAssignPublicIP:   envBool("BACKFLOW_ECS_ASSIGN_PUBLIC_IP", true),
-		ContainerCPUs:       envInt("BACKFLOW_CONTAINER_CPUS", 2),
-		ContainerMemGB:      envInt("BACKFLOW_CONTAINER_MEMORY_GB", 8),
-		LaunchTemplateID:    os.Getenv("BACKFLOW_LAUNCH_TEMPLATE_ID"),
-		CloudWatchLogGroup:  os.Getenv("BACKFLOW_CLOUDWATCH_LOG_GROUP"),
-		ECSLogStreamPrefix:  envOr("BACKFLOW_ECS_LOG_STREAM_PREFIX", "ecs"),
-		MaxConcurrentTasks:  envInt("BACKFLOW_MAX_CONCURRENT_TASKS", 5),
-		AgentImage:          envOr("BACKFLOW_AGENT_IMAGE", "backflow-agent"),
-		DefaultHarness:      envOr("BACKFLOW_DEFAULT_HARNESS", "claude_code"),
-		DefaultClaudeModel:  envOr("BACKFLOW_DEFAULT_CLAUDE_MODEL", "claude-sonnet-4-6"),
-		DefaultCodexModel:   envOr("BACKFLOW_DEFAULT_CODEX_MODEL", "gpt-5.4"),
-		DefaultEffort:       envOr("BACKFLOW_DEFAULT_EFFORT", "medium"),
-		DefaultMaxBudget:    envFloat("BACKFLOW_DEFAULT_MAX_BUDGET", 10.0),
-		DefaultMaxRuntime:   time.Duration(envInt("BACKFLOW_DEFAULT_MAX_RUNTIME_SEC", 1800)) * time.Second,
-		DefaultMaxTurns:     envInt("BACKFLOW_DEFAULT_MAX_TURNS", 200),
-		S3Bucket:            os.Getenv("BACKFLOW_S3_BUCKET"),
-		GitHubToken:         os.Getenv("GITHUB_TOKEN"),
-		WebhookURL:          os.Getenv("BACKFLOW_WEBHOOK_URL"),
-		SlackWebhookURL:     os.Getenv("BACKFLOW_SLACK_WEBHOOK_URL"),
-		SlackEvents:         envCSV("BACKFLOW_SLACK_EVENTS"),
-		DiscordAppID:        os.Getenv("BACKFLOW_DISCORD_APP_ID"),
-		DiscordPublicKey:    os.Getenv("BACKFLOW_DISCORD_PUBLIC_KEY"),
-		DiscordBotToken:     os.Getenv("BACKFLOW_DISCORD_BOT_TOKEN"),
-		DiscordGuildID:      os.Getenv("BACKFLOW_DISCORD_GUILD_ID"),
-		DiscordChannelID:    os.Getenv("BACKFLOW_DISCORD_CHANNEL_ID"),
-		DiscordCommandName:  envOr("BACKFLOW_DISCORD_COMMAND_NAME", "backflow"),
-		DiscordAllowedRoles: envCSV("BACKFLOW_DISCORD_ALLOWED_ROLES"),
-		DiscordEvents:       envCSV("BACKFLOW_DISCORD_EVENTS"),
-		LogFile:             os.Getenv("BACKFLOW_LOG_FILE"),
-		DatabaseURL:         os.Getenv("BACKFLOW_DATABASE_URL"),
-		MaxUserRetries:      envInt("BACKFLOW_MAX_USER_RETRIES", 2),
-		PollInterval:        time.Duration(envInt("BACKFLOW_POLL_INTERVAL_SEC", 5)) * time.Second,
+		Mode:                    Mode(envOr("BACKFLOW_MODE", string(ModeEC2))),
+		ListenAddr:              envOr("BACKFLOW_LISTEN_ADDR", ":8080"),
+		APIKey:                  os.Getenv("BACKFLOW_API_KEY"),
+		AnthropicAPIKey:         os.Getenv("ANTHROPIC_API_KEY"),
+		OpenAIAPIKey:            os.Getenv("OPENAI_API_KEY"),
+		AWSRegion:               envOr("AWS_REGION", "us-east-1"),
+		InstanceType:            envOr("BACKFLOW_INSTANCE_TYPE", "m7g.xlarge"),
+		AMI:                     os.Getenv("BACKFLOW_AMI"),
+		MaxInstances:            envInt("BACKFLOW_MAX_INSTANCES", 5),
+		ContainersPerInst:       envInt("BACKFLOW_CONTAINERS_PER_INSTANCE", 1),
+		ECSCluster:              os.Getenv("BACKFLOW_ECS_CLUSTER"),
+		ECSTaskDefinition:       os.Getenv("BACKFLOW_ECS_TASK_DEFINITION"),
+		ECSReaderTaskDefinition: os.Getenv("BACKFLOW_ECS_READER_TASK_DEFINITION"),
+		ECSSubnets:              envCSV("BACKFLOW_ECS_SUBNETS"),
+		ECSSecurityGroups:       envCSV("BACKFLOW_ECS_SECURITY_GROUPS"),
+		ECSLaunchType:           strings.ToUpper(envOr("BACKFLOW_ECS_LAUNCH_TYPE", "FARGATE_SPOT")),
+		ECSContainerName:        envOr("BACKFLOW_ECS_CONTAINER_NAME", "backflow-agent"),
+		ECSAssignPublicIP:       envBool("BACKFLOW_ECS_ASSIGN_PUBLIC_IP", true),
+		ContainerCPUs:           envInt("BACKFLOW_CONTAINER_CPUS", 2),
+		ContainerMemGB:          envInt("BACKFLOW_CONTAINER_MEMORY_GB", 8),
+		LaunchTemplateID:        os.Getenv("BACKFLOW_LAUNCH_TEMPLATE_ID"),
+		CloudWatchLogGroup:      os.Getenv("BACKFLOW_CLOUDWATCH_LOG_GROUP"),
+		ECSLogStreamPrefix:      envOr("BACKFLOW_ECS_LOG_STREAM_PREFIX", "ecs"),
+		MaxConcurrentTasks:      envInt("BACKFLOW_MAX_CONCURRENT_TASKS", 5),
+		AgentImage:              envOr("BACKFLOW_AGENT_IMAGE", "backflow-agent"),
+		ReaderImage:             os.Getenv("BACKFLOW_READER_IMAGE"),
+		DefaultHarness:          envOr("BACKFLOW_DEFAULT_HARNESS", "claude_code"),
+		DefaultClaudeModel:      envOr("BACKFLOW_DEFAULT_CLAUDE_MODEL", "claude-sonnet-4-6"),
+		DefaultCodexModel:       envOr("BACKFLOW_DEFAULT_CODEX_MODEL", "gpt-5.4"),
+		DefaultEffort:           envOr("BACKFLOW_DEFAULT_EFFORT", "medium"),
+		DefaultMaxBudget:        envFloat("BACKFLOW_DEFAULT_MAX_BUDGET", 10.0),
+		DefaultMaxRuntime:       time.Duration(envInt("BACKFLOW_DEFAULT_MAX_RUNTIME_SEC", 1800)) * time.Second,
+		DefaultMaxTurns:         envInt("BACKFLOW_DEFAULT_MAX_TURNS", 200),
+		DefaultReadMaxBudget:    envFloat("BACKFLOW_DEFAULT_READ_MAX_BUDGET", 0),
+		DefaultReadMaxRuntime:   time.Duration(envInt("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC", 0)) * time.Second,
+		DefaultReadMaxTurns:     envInt("BACKFLOW_DEFAULT_READ_MAX_TURNS", 0),
+		SupabaseURL:             os.Getenv("SUPABASE_URL"),
+		SupabaseAnonKey:         os.Getenv("SUPABASE_ANON_KEY"),
+		S3Bucket:                os.Getenv("BACKFLOW_S3_BUCKET"),
+		GitHubToken:             os.Getenv("GITHUB_TOKEN"),
+		WebhookURL:              os.Getenv("BACKFLOW_WEBHOOK_URL"),
+		SlackWebhookURL:         os.Getenv("BACKFLOW_SLACK_WEBHOOK_URL"),
+		SlackEvents:             envCSV("BACKFLOW_SLACK_EVENTS"),
+		DiscordAppID:            os.Getenv("BACKFLOW_DISCORD_APP_ID"),
+		DiscordPublicKey:        os.Getenv("BACKFLOW_DISCORD_PUBLIC_KEY"),
+		DiscordBotToken:         os.Getenv("BACKFLOW_DISCORD_BOT_TOKEN"),
+		DiscordGuildID:          os.Getenv("BACKFLOW_DISCORD_GUILD_ID"),
+		DiscordChannelID:        os.Getenv("BACKFLOW_DISCORD_CHANNEL_ID"),
+		DiscordCommandName:      envOr("BACKFLOW_DISCORD_COMMAND_NAME", "backflow"),
+		DiscordAllowedRoles:     envCSV("BACKFLOW_DISCORD_ALLOWED_ROLES"),
+		DiscordEvents:           envCSV("BACKFLOW_DISCORD_EVENTS"),
+		LogFile:                 os.Getenv("BACKFLOW_LOG_FILE"),
+		DatabaseURL:             os.Getenv("BACKFLOW_DATABASE_URL"),
+		MaxUserRetries:          envInt("BACKFLOW_MAX_USER_RETRIES", 2),
+		PollInterval:            time.Duration(envInt("BACKFLOW_POLL_INTERVAL_SEC", 5)) * time.Second,
 	}
 
 	c.RestrictAPI = envBool("BACKFLOW_RESTRICT_API", false)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -368,3 +368,109 @@ func TestLoad_ReaderConfig_UnsetDefaults(t *testing.T) {
 		t.Errorf("ECSReaderTaskDefinition = %q, want empty when unset", cfg.ECSReaderTaskDefinition)
 	}
 }
+
+// setReaderEnv populates every required read-mode env var. Individual
+// "missing X" tests unset one var after calling this helper.
+func setReaderEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("BACKFLOW_DATABASE_URL", "postgres://user:pass@localhost:5432/db")
+	t.Setenv("BACKFLOW_READER_IMAGE", "backflow-reader:v1")
+	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_BUDGET", "0.5")
+	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC", "300")
+	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_TURNS", "20")
+	t.Setenv("SUPABASE_URL", "https://test.supabase.co")
+	t.Setenv("SUPABASE_ANON_KEY", "sb_publishable_test")
+}
+
+func TestLoad_ReaderImage_RequiresReadMaxBudget(t *testing.T) {
+	setReaderEnv(t)
+	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_BUDGET", "0")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when BACKFLOW_DEFAULT_READ_MAX_BUDGET is unset with reader image")
+	}
+	if !strings.Contains(err.Error(), "BACKFLOW_DEFAULT_READ_MAX_BUDGET") {
+		t.Errorf("error should name the missing env var, got: %v", err)
+	}
+}
+
+func TestLoad_ReaderImage_RequiresReadMaxRuntime(t *testing.T) {
+	setReaderEnv(t)
+	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC", "0")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC is unset with reader image")
+	}
+	if !strings.Contains(err.Error(), "BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC") {
+		t.Errorf("error should name the missing env var, got: %v", err)
+	}
+}
+
+func TestLoad_ReaderImage_RequiresReadMaxTurns(t *testing.T) {
+	setReaderEnv(t)
+	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_TURNS", "0")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when BACKFLOW_DEFAULT_READ_MAX_TURNS is unset with reader image")
+	}
+	if !strings.Contains(err.Error(), "BACKFLOW_DEFAULT_READ_MAX_TURNS") {
+		t.Errorf("error should name the missing env var, got: %v", err)
+	}
+}
+
+func TestLoad_ReaderImage_RequiresSupabaseURL(t *testing.T) {
+	setReaderEnv(t)
+	t.Setenv("SUPABASE_URL", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when SUPABASE_URL is unset with reader image")
+	}
+	if !strings.Contains(err.Error(), "SUPABASE_URL") {
+		t.Errorf("error should name the missing env var, got: %v", err)
+	}
+}
+
+func TestLoad_ReaderImage_RequiresSupabaseAnonKey(t *testing.T) {
+	setReaderEnv(t)
+	t.Setenv("SUPABASE_ANON_KEY", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when SUPABASE_ANON_KEY is unset with reader image")
+	}
+	if !strings.Contains(err.Error(), "SUPABASE_ANON_KEY") {
+		t.Errorf("error should name the missing env var, got: %v", err)
+	}
+}
+
+func TestLoad_ReaderImage_Fargate_RequiresReaderTaskDefinition(t *testing.T) {
+	setReaderEnv(t)
+	// Fargate mode with the standard required vars, reader image set, but no reader task def.
+	t.Setenv("BACKFLOW_MODE", "fargate")
+	t.Setenv("BACKFLOW_ECS_CLUSTER", "cluster")
+	t.Setenv("BACKFLOW_ECS_TASK_DEFINITION", "code-td")
+	t.Setenv("BACKFLOW_ECS_SUBNETS", "subnet-1")
+	t.Setenv("BACKFLOW_CLOUDWATCH_LOG_GROUP", "/backflow")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when BACKFLOW_ECS_READER_TASK_DEFINITION is unset in fargate mode with reader image")
+	}
+	if !strings.Contains(err.Error(), "BACKFLOW_ECS_READER_TASK_DEFINITION") {
+		t.Errorf("error should name the missing env var, got: %v", err)
+	}
+}
+
+func TestLoad_ReaderImage_NonFargate_DoesNotRequireReaderTaskDefinition(t *testing.T) {
+	setReaderEnv(t)
+	t.Setenv("BACKFLOW_MODE", "local")
+
+	if _, err := Load(); err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoad_MissingDatabaseURL(t *testing.T) {
@@ -296,5 +297,74 @@ func TestLoad_SMSOutboundEnabled_ExplicitFalse(t *testing.T) {
 	}
 	if cfg.SMSOutboundEnabled {
 		t.Error("SMSOutboundEnabled = true, want false (explicitly disabled)")
+	}
+}
+
+func TestLoad_ReaderConfig(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("BACKFLOW_DATABASE_URL", "postgres://user:pass@localhost:5432/db")
+	t.Setenv("BACKFLOW_READER_IMAGE", "backflow-reader:v1")
+	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_BUDGET", "0.5")
+	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC", "300")
+	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_TURNS", "20")
+	t.Setenv("SUPABASE_URL", "https://test.supabase.co")
+	t.Setenv("SUPABASE_ANON_KEY", "sb_publishable_test")
+	t.Setenv("BACKFLOW_ECS_READER_TASK_DEFINITION", "backflow-reader-td:3")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+	if cfg.ReaderImage != "backflow-reader:v1" {
+		t.Errorf("ReaderImage = %q, want %q", cfg.ReaderImage, "backflow-reader:v1")
+	}
+	if cfg.DefaultReadMaxBudget != 0.5 {
+		t.Errorf("DefaultReadMaxBudget = %v, want %v", cfg.DefaultReadMaxBudget, 0.5)
+	}
+	if cfg.DefaultReadMaxRuntime != 300*time.Second {
+		t.Errorf("DefaultReadMaxRuntime = %v, want %v", cfg.DefaultReadMaxRuntime, 300*time.Second)
+	}
+	if cfg.DefaultReadMaxTurns != 20 {
+		t.Errorf("DefaultReadMaxTurns = %d, want %d", cfg.DefaultReadMaxTurns, 20)
+	}
+	if cfg.SupabaseURL != "https://test.supabase.co" {
+		t.Errorf("SupabaseURL = %q, want %q", cfg.SupabaseURL, "https://test.supabase.co")
+	}
+	if cfg.SupabaseAnonKey != "sb_publishable_test" {
+		t.Errorf("SupabaseAnonKey = %q, want %q", cfg.SupabaseAnonKey, "sb_publishable_test")
+	}
+	if cfg.ECSReaderTaskDefinition != "backflow-reader-td:3" {
+		t.Errorf("ECSReaderTaskDefinition = %q, want %q", cfg.ECSReaderTaskDefinition, "backflow-reader-td:3")
+	}
+}
+
+func TestLoad_ReaderConfig_UnsetDefaults(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("BACKFLOW_DATABASE_URL", "postgres://user:pass@localhost:5432/db")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+	if cfg.ReaderImage != "" {
+		t.Errorf("ReaderImage = %q, want empty when unset", cfg.ReaderImage)
+	}
+	if cfg.DefaultReadMaxBudget != 0 {
+		t.Errorf("DefaultReadMaxBudget = %v, want 0 when unset", cfg.DefaultReadMaxBudget)
+	}
+	if cfg.DefaultReadMaxRuntime != 0 {
+		t.Errorf("DefaultReadMaxRuntime = %v, want 0 when unset", cfg.DefaultReadMaxRuntime)
+	}
+	if cfg.DefaultReadMaxTurns != 0 {
+		t.Errorf("DefaultReadMaxTurns = %d, want 0 when unset", cfg.DefaultReadMaxTurns)
+	}
+	if cfg.SupabaseURL != "" {
+		t.Errorf("SupabaseURL = %q, want empty when unset", cfg.SupabaseURL)
+	}
+	if cfg.SupabaseAnonKey != "" {
+		t.Errorf("SupabaseAnonKey = %q, want empty when unset", cfg.SupabaseAnonKey)
+	}
+	if cfg.ECSReaderTaskDefinition != "" {
+		t.Errorf("ECSReaderTaskDefinition = %q, want empty when unset", cfg.ECSReaderTaskDefinition)
 	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -4,6 +4,7 @@ import "github.com/backflow-labs/backflow/internal/models"
 
 // TaskDefaults holds resolved default values for new tasks.
 type TaskDefaults struct {
+	AgentImage      string
 	Harness         string
 	ClaudeModel     string
 	CodexModel      string
@@ -27,6 +28,7 @@ type BoolOverrides struct {
 // TaskDefaults returns resolved defaults for the given task mode.
 func (c *Config) TaskDefaults(taskMode string) TaskDefaults {
 	d := TaskDefaults{
+		AgentImage:      c.AgentImage,
 		Harness:         c.DefaultHarness,
 		ClaudeModel:     c.DefaultClaudeModel,
 		CodexModel:      c.DefaultCodexModel,
@@ -39,7 +41,14 @@ func (c *Config) TaskDefaults(taskMode string) TaskDefaults {
 		SaveAgentOutput: c.DefaultSaveOutput,
 	}
 
-	if taskMode == models.TaskModeReview {
+	switch taskMode {
+	case models.TaskModeReview:
+		d.CreatePR = false
+	case models.TaskModeRead:
+		d.AgentImage = c.ReaderImage
+		d.MaxBudgetUSD = c.DefaultReadMaxBudget
+		d.MaxRuntimeSec = int(c.DefaultReadMaxRuntime.Seconds())
+		d.MaxTurns = c.DefaultReadMaxTurns
 		d.CreatePR = false
 	}
 	// Auto mode uses the same defaults as code mode (superset).
@@ -64,6 +73,9 @@ func (d TaskDefaults) Apply(task *models.Task, overrides *BoolOverrides) {
 	if task.Effort == "" {
 		task.Effort = d.Effort
 	}
+	if task.AgentImage == "" {
+		task.AgentImage = d.AgentImage
+	}
 	if task.MaxBudgetUSD == 0 {
 		task.MaxBudgetUSD = d.MaxBudgetUSD
 	}
@@ -75,8 +87,8 @@ func (d TaskDefaults) Apply(task *models.Task, overrides *BoolOverrides) {
 	}
 
 	// Booleans: use override if provided, otherwise default.
-	// Review mode always forces CreatePR=false regardless of override.
-	if task.TaskMode == models.TaskModeReview {
+	// Review and read modes always force CreatePR=false regardless of override.
+	if task.TaskMode == models.TaskModeReview || task.TaskMode == models.TaskModeRead {
 		task.CreatePR = false
 	} else {
 		task.CreatePR = boolOrDefault(overrides.createPR(), d.CreatePR)

--- a/internal/config/defaults_test.go
+++ b/internal/config/defaults_test.go
@@ -9,16 +9,21 @@ import (
 
 func testConfig() *Config {
 	return &Config{
-		DefaultHarness:     "claude_code",
-		DefaultClaudeModel: "claude-sonnet-4-6",
-		DefaultCodexModel:  "gpt-5.4",
-		DefaultEffort:      "medium",
-		DefaultMaxBudget:   10.0,
-		DefaultMaxRuntime:  1800 * time.Second,
-		DefaultMaxTurns:    200,
-		DefaultCreatePR:    true,
-		DefaultSelfReview:  false,
-		DefaultSaveOutput:  true,
+		AgentImage:            "backflow-agent",
+		ReaderImage:           "backflow-reader",
+		DefaultHarness:        "claude_code",
+		DefaultClaudeModel:    "claude-sonnet-4-6",
+		DefaultCodexModel:     "gpt-5.4",
+		DefaultEffort:         "medium",
+		DefaultMaxBudget:      10.0,
+		DefaultMaxRuntime:     1800 * time.Second,
+		DefaultMaxTurns:       200,
+		DefaultReadMaxBudget:  0.5,
+		DefaultReadMaxRuntime: 300 * time.Second,
+		DefaultReadMaxTurns:   20,
+		DefaultCreatePR:       true,
+		DefaultSelfReview:     false,
+		DefaultSaveOutput:     true,
 	}
 }
 
@@ -71,6 +76,35 @@ func TestTaskDefaults_ReviewMode(t *testing.T) {
 	}
 	if !d.SaveAgentOutput {
 		t.Error("SaveAgentOutput = false, want true")
+	}
+}
+
+func TestTaskDefaults_ReadMode(t *testing.T) {
+	cfg := testConfig()
+	d := cfg.TaskDefaults(models.TaskModeRead)
+
+	if d.AgentImage != "backflow-reader" {
+		t.Errorf("AgentImage = %q, want %q", d.AgentImage, "backflow-reader")
+	}
+	if d.MaxBudgetUSD != 0.5 {
+		t.Errorf("MaxBudgetUSD = %v, want %v (read cap)", d.MaxBudgetUSD, 0.5)
+	}
+	if d.MaxRuntimeSec != 300 {
+		t.Errorf("MaxRuntimeSec = %d, want %d (read cap)", d.MaxRuntimeSec, 300)
+	}
+	if d.MaxTurns != 20 {
+		t.Errorf("MaxTurns = %d, want %d (read cap)", d.MaxTurns, 20)
+	}
+	if d.CreatePR {
+		t.Error("CreatePR = true, want false in read mode")
+	}
+}
+
+func TestTaskDefaults_CodeMode_AgentImage(t *testing.T) {
+	cfg := testConfig()
+	d := cfg.TaskDefaults(models.TaskModeCode)
+	if d.AgentImage != "backflow-agent" {
+		t.Errorf("AgentImage = %q, want %q in code mode", d.AgentImage, "backflow-agent")
 	}
 }
 
@@ -208,6 +242,42 @@ func TestApply_HarnessModelCoupling(t *testing.T) {
 	}
 	if task.Model == claudeModel {
 		t.Errorf("codex model %q should differ from claude model %q", task.Model, claudeModel)
+	}
+}
+
+func TestApply_FillsAgentImage(t *testing.T) {
+	cfg := testConfig()
+	d := cfg.TaskDefaults(models.TaskModeRead)
+	task := &models.Task{TaskMode: models.TaskModeRead}
+
+	d.Apply(task, nil)
+
+	if task.AgentImage != "backflow-reader" {
+		t.Errorf("AgentImage = %q, want %q (from read defaults)", task.AgentImage, "backflow-reader")
+	}
+}
+
+func TestApply_PreservesExplicitAgentImage(t *testing.T) {
+	cfg := testConfig()
+	d := cfg.TaskDefaults(models.TaskModeCode)
+	task := &models.Task{AgentImage: "custom:tag"}
+
+	d.Apply(task, nil)
+
+	if task.AgentImage != "custom:tag" {
+		t.Errorf("AgentImage = %q, want %q (preserve explicit)", task.AgentImage, "custom:tag")
+	}
+}
+
+func TestApply_ReadModeIgnoresCreatePROverride(t *testing.T) {
+	cfg := testConfig()
+	d := cfg.TaskDefaults(models.TaskModeRead)
+	task := &models.Task{TaskMode: models.TaskModeRead}
+
+	d.Apply(task, &BoolOverrides{CreatePR: boolPtr(true)})
+
+	if task.CreatePR {
+		t.Error("CreatePR = true, want false — read mode should ignore CreatePR override")
 	}
 }
 

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -31,6 +31,7 @@ const (
 	TaskModeAuto   = "auto"   // Prep stage infers code or review from the prompt
 	TaskModeCode   = "code"   // Default: clone, code, commit, push, optionally create PR
 	TaskModeReview = "review" // Review an existing PR and post feedback as comments
+	TaskModeRead   = "read"   // Fetch a URL, summarize it, and store the reading
 )
 
 type Harness string
@@ -52,6 +53,7 @@ type Task struct {
 	Context         string            `json:"context,omitempty"`
 	Model           string            `json:"model,omitempty"`
 	Effort          string            `json:"effort,omitempty"`
+	AgentImage      string            `json:"agent_image,omitempty"`
 	MaxBudgetUSD    float64           `json:"max_budget_usd,omitempty"`
 	MaxRuntimeSec   int               `json:"max_runtime_sec,omitempty"`
 	MaxTurns        int               `json:"max_turns,omitempty"`
@@ -159,6 +161,8 @@ var reservedEnvVarKeys = map[string]bool{
 	"ANTHROPIC_API_KEY": true,
 	"OPENAI_API_KEY":    true,
 	"GITHUB_TOKEN":      true,
+	"SUPABASE_URL":      true,
+	"SUPABASE_ANON_KEY": true,
 }
 
 // containsNullByte returns true if s contains a null byte, which PostgreSQL

--- a/internal/models/task_test.go
+++ b/internal/models/task_test.go
@@ -1,6 +1,10 @@
 package models
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func TestCreateTaskRequestValidation(t *testing.T) {
 	tests := []struct {
@@ -199,6 +203,16 @@ func TestCreateTaskRequestValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "reserved env var key SUPABASE_URL",
+			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"SUPABASE_URL": "https://evil.supabase.co"}},
+			wantErr: true,
+		},
+		{
+			name:    "reserved env var key SUPABASE_ANON_KEY",
+			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"SUPABASE_ANON_KEY": "sb_publishable_attacker"}},
+			wantErr: true,
+		},
+		{
 			name:    "non-reserved env var key allowed",
 			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"MY_CUSTOM_VAR": "val"}},
 			wantErr: false,
@@ -212,6 +226,31 @@ func TestCreateTaskRequestValidation(t *testing.T) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestTaskAgentImageJSON(t *testing.T) {
+	task := Task{ID: "bf_test", AgentImage: "backflow-reader:v1"}
+	data, err := json.Marshal(task)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"agent_image":"backflow-reader:v1"`) {
+		t.Errorf("missing agent_image in marshaled task: %s", data)
+	}
+
+	var got Task
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.AgentImage != "backflow-reader:v1" {
+		t.Errorf("AgentImage = %q, want %q", got.AgentImage, "backflow-reader:v1")
+	}
+}
+
+func TestTaskModeReadConstant(t *testing.T) {
+	if TaskModeRead != "read" {
+		t.Errorf("TaskModeRead = %q, want %q", TaskModeRead, "read")
 	}
 }
 

--- a/internal/orchestrator/docker/docker.go
+++ b/internal/orchestrator/docker/docker.go
@@ -113,6 +113,11 @@ func (m *Manager) buildRunCommand(task *models.Task, envFilePath string) string 
 		envFileFlag = "--env-file " + envFilePath
 	}
 
+	image := task.AgentImage
+	if image == "" {
+		image = m.config.AgentImage
+	}
+
 	return fmt.Sprintf(
 		"docker run -d --cpus=%d --memory=%dg %s %s %s %s",
 		m.config.ContainerCPUs,
@@ -120,7 +125,7 @@ func (m *Manager) buildRunCommand(task *models.Task, envFilePath string) string 
 		envFileFlag,
 		volumeFlags,
 		strings.Join(envFlags, " "),
-		m.config.AgentImage,
+		image,
 	)
 }
 
@@ -154,6 +159,17 @@ func (m *Manager) buildEnvFlags(task *models.Task) []string {
 	}
 	if task.Context != "" {
 		flags = append(flags, envFlag("TASK_CONTEXT", shellEscape(task.Context)))
+	}
+
+	if task.TaskMode == models.TaskModeRead {
+		// SUPABASE_ANON_KEY is a low-privilege publishable JWT (RLS-scoped SELECT only),
+		// so it's passed via -e rather than --env-file.
+		if m.config.SupabaseURL != "" {
+			flags = append(flags, envFlag("SUPABASE_URL", shellEscape(m.config.SupabaseURL)))
+		}
+		if m.config.SupabaseAnonKey != "" {
+			flags = append(flags, envFlag("SUPABASE_ANON_KEY", shellEscape(m.config.SupabaseAnonKey)))
+		}
 	}
 
 	for k, v := range task.EnvVars {

--- a/internal/orchestrator/docker/docker_test.go
+++ b/internal/orchestrator/docker/docker_test.go
@@ -244,6 +244,98 @@ func TestBuildRunCommand_CustomImage(t *testing.T) {
 	}
 }
 
+func TestBuildEnvFlags_ReadModeIncludesSupabase(t *testing.T) {
+	cfg := &config.Config{
+		SupabaseURL:     "https://test.supabase.co",
+		SupabaseAnonKey: "sb_publishable_test",
+	}
+	dm := NewManager(cfg)
+	task := &models.Task{ID: "bf_01ABC", TaskMode: models.TaskModeRead}
+
+	joined := strings.Join(dm.buildEnvFlags(task), " ")
+
+	if !strings.Contains(joined, "-e SUPABASE_URL='https://test.supabase.co'") {
+		t.Errorf("flags should include SUPABASE_URL, got: %s", joined)
+	}
+	if !strings.Contains(joined, "-e SUPABASE_ANON_KEY='sb_publishable_test'") {
+		t.Errorf("flags should include SUPABASE_ANON_KEY, got: %s", joined)
+	}
+}
+
+func TestBuildEnvFlags_NonReadModeOmitsSupabase(t *testing.T) {
+	cfg := &config.Config{
+		SupabaseURL:     "https://test.supabase.co",
+		SupabaseAnonKey: "sb_publishable_test",
+	}
+	dm := NewManager(cfg)
+	task := &models.Task{ID: "bf_01ABC", TaskMode: models.TaskModeCode}
+
+	joined := strings.Join(dm.buildEnvFlags(task), " ")
+
+	if strings.Contains(joined, "SUPABASE_URL") {
+		t.Errorf("flags should not include SUPABASE_URL for non-read mode, got: %s", joined)
+	}
+	if strings.Contains(joined, "SUPABASE_ANON_KEY") {
+		t.Errorf("flags should not include SUPABASE_ANON_KEY for non-read mode, got: %s", joined)
+	}
+}
+
+func TestBuildEnvFlags_ReadModeMissingSupabaseConfig(t *testing.T) {
+	cfg := &config.Config{}
+	dm := NewManager(cfg)
+	task := &models.Task{ID: "bf_01ABC", TaskMode: models.TaskModeRead}
+
+	joined := strings.Join(dm.buildEnvFlags(task), " ")
+
+	if strings.Contains(joined, "SUPABASE_URL") {
+		t.Errorf("flags should omit SUPABASE_URL when cfg is empty, got: %s", joined)
+	}
+	if strings.Contains(joined, "SUPABASE_ANON_KEY") {
+		t.Errorf("flags should omit SUPABASE_ANON_KEY when cfg is empty, got: %s", joined)
+	}
+}
+
+func TestBuildRunCommand_UsesTaskAgentImage(t *testing.T) {
+	cfg := &config.Config{
+		ContainerCPUs:  2,
+		ContainerMemGB: 8,
+		AgentImage:     "backflow-agent",
+	}
+	dm := NewManager(cfg)
+	task := &models.Task{
+		ID:         "bf_01ABC",
+		AgentImage: "backflow-reader:v1",
+	}
+
+	cmd := dm.buildRunCommand(task, "")
+
+	if !strings.HasSuffix(cmd, "backflow-reader:v1") {
+		t.Errorf("command should end with task.AgentImage, got: %s", cmd)
+	}
+	if strings.HasSuffix(cmd, "backflow-agent") {
+		t.Errorf("command should not fall back to cfg.AgentImage when task.AgentImage is set, got: %s", cmd)
+	}
+}
+
+func TestBuildRunCommand_FallsBackToConfigAgentImage(t *testing.T) {
+	cfg := &config.Config{
+		ContainerCPUs:  2,
+		ContainerMemGB: 8,
+		AgentImage:     "backflow-agent",
+	}
+	dm := NewManager(cfg)
+	task := &models.Task{
+		ID:         "bf_01ABC",
+		AgentImage: "",
+	}
+
+	cmd := dm.buildRunCommand(task, "")
+
+	if !strings.HasSuffix(cmd, "backflow-agent") {
+		t.Errorf("command should fall back to cfg.AgentImage when task.AgentImage is empty, got: %s", cmd)
+	}
+}
+
 func TestBuildSecretEnvPairs(t *testing.T) {
 	cfg := &config.Config{
 		AnthropicAPIKey: "sk-test-key",

--- a/internal/orchestrator/fargate/fargate.go
+++ b/internal/orchestrator/fargate/fargate.go
@@ -93,7 +93,7 @@ func (m *Manager) RunAgent(ctx context.Context, _ *models.Instance, task *models
 
 	input := &ecs.RunTaskInput{
 		Cluster:        aws.String(m.config.ECSCluster),
-		TaskDefinition: aws.String(m.config.ECSTaskDefinition),
+		TaskDefinition: aws.String(m.selectTaskDefinition(task)),
 		Count:          aws.Int32(1),
 		ClientToken:    aws.String(task.ID),
 		StartedBy:      aws.String(task.ID),
@@ -272,6 +272,15 @@ func (m *Manager) buildECSEnvVars(task *models.Task) []ecstypes.KeyValuePair {
 		vars = append(vars, ecsEnvVar("GITHUB_TOKEN", m.config.GitHubToken))
 	}
 
+	if task.TaskMode == models.TaskModeRead {
+		if m.config.SupabaseURL != "" {
+			vars = append(vars, ecsEnvVar("SUPABASE_URL", m.config.SupabaseURL))
+		}
+		if m.config.SupabaseAnonKey != "" {
+			vars = append(vars, ecsEnvVar("SUPABASE_ANON_KEY", m.config.SupabaseAnonKey))
+		}
+	}
+
 	keys := make([]string, 0, len(task.EnvVars))
 	for key := range task.EnvVars {
 		keys = append(keys, key)
@@ -312,6 +321,17 @@ func (m *Manager) buildLogStreamName(taskARN string) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%s/%s/%s", m.logStreamPrefix(), m.containerName(), taskID), nil
+}
+
+// selectTaskDefinition returns the ECS task definition to use for a task.
+// ECS ContainerOverride cannot override the container image, so reader-mode
+// tasks need their own task definition. Falls back to the default when the
+// reader task definition isn't configured.
+func (m *Manager) selectTaskDefinition(task *models.Task) string {
+	if task.TaskMode == models.TaskModeRead && m.config.ECSReaderTaskDefinition != "" {
+		return m.config.ECSReaderTaskDefinition
+	}
+	return m.config.ECSTaskDefinition
 }
 
 func (m *Manager) containerName() string {

--- a/internal/orchestrator/fargate/fargate_test.go
+++ b/internal/orchestrator/fargate/fargate_test.go
@@ -86,6 +86,103 @@ func TestFargateBuildECSEnvVars(t *testing.T) {
 	}
 }
 
+func TestFargate_SelectTaskDefinition(t *testing.T) {
+	cases := []struct {
+		name     string
+		cfg      *config.Config
+		taskMode string
+		want     string
+	}{
+		{
+			name:     "read mode with reader task def set",
+			cfg:      &config.Config{ECSTaskDefinition: "agent-td:1", ECSReaderTaskDefinition: "reader-td:3"},
+			taskMode: models.TaskModeRead,
+			want:     "reader-td:3",
+		},
+		{
+			name:     "read mode with reader task def empty falls back",
+			cfg:      &config.Config{ECSTaskDefinition: "agent-td:1"},
+			taskMode: models.TaskModeRead,
+			want:     "agent-td:1",
+		},
+		{
+			name:     "code mode ignores reader task def",
+			cfg:      &config.Config{ECSTaskDefinition: "agent-td:1", ECSReaderTaskDefinition: "reader-td:3"},
+			taskMode: models.TaskModeCode,
+			want:     "agent-td:1",
+		},
+		{
+			name:     "review mode ignores reader task def",
+			cfg:      &config.Config{ECSTaskDefinition: "agent-td:1", ECSReaderTaskDefinition: "reader-td:3"},
+			taskMode: models.TaskModeReview,
+			want:     "agent-td:1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewManager(tc.cfg, nil)
+			got := m.selectTaskDefinition(&models.Task{TaskMode: tc.taskMode})
+			if got != tc.want {
+				t.Errorf("selectTaskDefinition = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFargateBuildECSEnvVars_ReadModeIncludesSupabase(t *testing.T) {
+	manager := NewManager(&config.Config{
+		SupabaseURL:     "https://test.supabase.co",
+		SupabaseAnonKey: "sb_publishable_test",
+	}, nil)
+	task := &models.Task{ID: "bf_01ABC", TaskMode: models.TaskModeRead}
+
+	envVars := manager.buildECSEnvVars(task)
+	got := make(map[string]string, len(envVars))
+	for _, pair := range envVars {
+		got[aws.ToString(pair.Name)] = aws.ToString(pair.Value)
+	}
+
+	if got["SUPABASE_URL"] != "https://test.supabase.co" {
+		t.Errorf("SUPABASE_URL = %q, want %q", got["SUPABASE_URL"], "https://test.supabase.co")
+	}
+	if got["SUPABASE_ANON_KEY"] != "sb_publishable_test" {
+		t.Errorf("SUPABASE_ANON_KEY = %q, want %q", got["SUPABASE_ANON_KEY"], "sb_publishable_test")
+	}
+}
+
+func TestFargateBuildECSEnvVars_NonReadModeOmitsSupabase(t *testing.T) {
+	manager := NewManager(&config.Config{
+		SupabaseURL:     "https://test.supabase.co",
+		SupabaseAnonKey: "sb_publishable_test",
+	}, nil)
+	task := &models.Task{ID: "bf_01ABC", TaskMode: models.TaskModeCode}
+
+	envVars := manager.buildECSEnvVars(task)
+	for _, pair := range envVars {
+		if aws.ToString(pair.Name) == "SUPABASE_URL" {
+			t.Error("SUPABASE_URL should be omitted for non-read mode")
+		}
+		if aws.ToString(pair.Name) == "SUPABASE_ANON_KEY" {
+			t.Error("SUPABASE_ANON_KEY should be omitted for non-read mode")
+		}
+	}
+}
+
+func TestFargateBuildECSEnvVars_ReadModeMissingSupabaseConfig(t *testing.T) {
+	manager := NewManager(&config.Config{}, nil)
+	task := &models.Task{ID: "bf_01ABC", TaskMode: models.TaskModeRead}
+
+	envVars := manager.buildECSEnvVars(task)
+	for _, pair := range envVars {
+		if aws.ToString(pair.Name) == "SUPABASE_URL" {
+			t.Error("SUPABASE_URL should be omitted when cfg value is empty")
+		}
+		if aws.ToString(pair.Name) == "SUPABASE_ANON_KEY" {
+			t.Error("SUPABASE_ANON_KEY should be omitted when cfg value is empty")
+		}
+	}
+}
+
 func TestFargateMapECSTaskStatus(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -74,7 +74,7 @@ const taskColumns = `id, status, task_mode, harness, repo_url, branch, target_br
 	create_pr, self_review, save_agent_output, pr_title, pr_body, pr_url, output_url,
 	allowed_tools, claude_md, env_vars,
 	instance_id, container_id, retry_count, user_retry_count, cost_usd, elapsed_time_sec, error,
-	ready_for_retry, reply_channel,
+	ready_for_retry, reply_channel, agent_image,
 	created_at, updated_at, started_at, completed_at`
 
 func (s *PostgresStore) CreateTask(ctx context.Context, task *models.Task) error {
@@ -95,7 +95,7 @@ func (s *PostgresStore) CreateTask(ctx context.Context, task *models.Task) error
 			create_pr, self_review, save_agent_output, pr_title, pr_body, pr_url, output_url,
 			allowed_tools, claude_md, env_vars,
 			instance_id, container_id, retry_count, user_retry_count, cost_usd, elapsed_time_sec, error,
-			ready_for_retry, reply_channel,
+			ready_for_retry, reply_channel, agent_image,
 			created_at, updated_at, started_at, completed_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7,
@@ -104,8 +104,8 @@ func (s *PostgresStore) CreateTask(ctx context.Context, task *models.Task) error
 			$15, $16, $17, $18, $19, $20, $21,
 			$22, $23, $24,
 			$25, $26, $27, $28, $29, $30, $31,
-			$32, $33,
-			$34, $35, $36, $37
+			$32, $33, $34,
+			$35, $36, $37, $38
 		)`,
 		task.ID, task.Status, task.TaskMode, task.Harness, task.RepoURL, task.Branch, task.TargetBranch,
 		task.Prompt, task.Context, task.Model, task.Effort,
@@ -114,7 +114,7 @@ func (s *PostgresStore) CreateTask(ctx context.Context, task *models.Task) error
 		task.PRTitle, task.PRBody, task.PRURL, task.OutputURL,
 		allowedTools, task.ClaudeMD, envVars,
 		task.InstanceID, task.ContainerID, task.RetryCount, task.UserRetryCount, task.CostUSD, task.ElapsedTimeSec, task.Error,
-		task.ReadyForRetry, task.ReplyChannel,
+		task.ReadyForRetry, task.ReplyChannel, task.AgentImage,
 		task.CreatedAt, task.UpdatedAt, task.StartedAt, task.CompletedAt,
 	)
 	return err
@@ -550,7 +550,7 @@ func scanPGTask(row pgScanner) (*models.Task, error) {
 		&t.PRTitle, &t.PRBody, &t.PRURL, &t.OutputURL,
 		&allowedTools, &t.ClaudeMD, &envVars,
 		&t.InstanceID, &t.ContainerID, &t.RetryCount, &t.UserRetryCount, &t.CostUSD, &t.ElapsedTimeSec, &t.Error,
-		&t.ReadyForRetry, &t.ReplyChannel,
+		&t.ReadyForRetry, &t.ReplyChannel, &t.AgentImage,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 	)
 	if err != nil {

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -140,6 +140,7 @@ func TestPG_TaskRoundTrip(t *testing.T) {
 		TargetBranch:    "main",
 		Prompt:          "Fix the bug",
 		Model:           "claude-sonnet-4-6",
+		AgentImage:      "backflow-agent:v2",
 		MaxBudgetUSD:    10.0,
 		MaxTurns:        200,
 		CreatePR:        true,
@@ -196,8 +197,38 @@ func TestPG_TaskRoundTrip(t *testing.T) {
 	if got.EnvVars["FOO"] != "bar" {
 		t.Errorf("EnvVars[FOO] = %q, want bar", got.EnvVars["FOO"])
 	}
+	if got.AgentImage != "backflow-agent:v2" {
+		t.Errorf("AgentImage = %q, want %q", got.AgentImage, "backflow-agent:v2")
+	}
 	if !got.CreatedAt.Equal(now) {
 		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, now)
+	}
+}
+
+func TestPG_TaskRoundTrip_DefaultAgentImage(t *testing.T) {
+	s := testPostgresStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	task := &models.Task{
+		ID:        "bf_TEST_NOIMG",
+		Status:    models.TaskStatusPending,
+		TaskMode:  models.TaskModeCode,
+		Harness:   models.HarnessClaudeCode,
+		Prompt:    "Fix bug",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	got, err := s.GetTask(ctx, "bf_TEST_NOIMG")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.AgentImage != "" {
+		t.Errorf("AgentImage = %q, want empty (default)", got.AgentImage)
 	}
 }
 


### PR DESCRIPTION
Closes #173.

## Summary

Wires per-task `agent_image` selection and reading-mode config defaults through the full task lifecycle (model → config → task creation → store → dispatch). Purely additive — existing code/review task creation and dispatch are untouched.

- Every task now records the agent image it ran to (operational metadata).
- Reading tasks get dedicated reader image + tighter default budget/runtime/turn caps.
- Reader containers receive `SUPABASE_URL` / `SUPABASE_ANON_KEY` for the Supabase data API.
- Fargate supports reader mode via a separate task definition (ECS `ContainerOverride` can't override image).

## Changes

### Model (`internal/models/task.go`)
- `AgentImage` field on `Task` (persisted to the `agent_image` column added by #179).
- New `TaskModeRead = "read"` constant.
- `SUPABASE_URL` and `SUPABASE_ANON_KEY` added to `reservedEnvVarKeys` (user env vars can't override).

### Config (`internal/config/config.go`)
New env vars (all optional):

| Env var | Field |
|---|---|
| `BACKFLOW_READER_IMAGE` | `ReaderImage` |
| `BACKFLOW_DEFAULT_READ_MAX_BUDGET` | `DefaultReadMaxBudget` |
| `BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC` | `DefaultReadMaxRuntime` |
| `BACKFLOW_DEFAULT_READ_MAX_TURNS` | `DefaultReadMaxTurns` |
| `SUPABASE_URL` | `SupabaseURL` |
| `SUPABASE_ANON_KEY` | `SupabaseAnonKey` |
| `BACKFLOW_ECS_READER_TASK_DEFINITION` | `ECSReaderTaskDefinition` |

### Defaults (`internal/config/defaults.go`)
- `TaskDefaults` gains `AgentImage`. Default is `cfg.AgentImage`; read mode overrides to `cfg.ReaderImage` and swaps in the tighter read caps with `CreatePR = false`.
- `Apply` fills zero `task.AgentImage` and forces `CreatePR = false` for both review and read modes (defense-in-depth against `BoolOverrides.CreatePR`).

### Task creation (`internal/api/task_creator.go`)
- New `NewReadTask` helper parallel to `NewTask`: sets `TaskMode = TaskModeRead`, validates, drops PR-specific request fields, applies read defaults, persists, emits `task.created`.
- `CreateTaskRequest` intentionally unchanged — read mode has no public entry point yet; a future Discord/API issue will add the caller.

### Store (`internal/store/postgres.go`)
- `agent_image` added to `taskColumns`, `CreateTask` INSERT (now 38 params), and `scanPGTask` in matching positions.

### Docker dispatch (`internal/orchestrator/docker/docker.go`)
- `buildRunCommand` uses `task.AgentImage`, falling back to `cfg.AgentImage` when empty (backwards compatibility for in-flight tasks during migration).
- `buildEnvFlags` appends `SUPABASE_URL` / `SUPABASE_ANON_KEY` only for read tasks, only when the cfg values are non-empty. Passed via `-e` (not `--env-file`) because `SUPABASE_ANON_KEY` is a low-privilege publishable JWT (RLS-scoped SELECT only per migration 011).

### Fargate dispatch (`internal/orchestrator/fargate/fargate.go`)
- New `selectTaskDefinition(task)` helper picks `cfg.ECSReaderTaskDefinition` when `task.TaskMode == "read"` and it's set, else falls back to `cfg.ECSTaskDefinition`. (ECS `ContainerOverride.Image` can't be overridden — reader tasks need their own TD.)
- `buildECSEnvVars` mirrors the Docker Supabase env-var logic.

## Test plan

TDD, vertical slices, red → green throughout. Full `make test` and `make lint` pass.

- [x] `models`: `AgentImage` JSON round-trip; `TaskModeRead == "read"`; validation rejects reserved `SUPABASE_*` env vars
- [x] `config`: `Load()` parses seven new env vars; `Load()` still succeeds when reader vars are unset
- [x] `defaults`: `TaskDefaults("read")` returns reader image + read caps + `CreatePR=false`; `Apply` fills zero `AgentImage`, preserves explicit image, ignores `CreatePR` override for read mode
- [x] `api`: `NewReadTask` sets mode/image/caps correctly, emits `task.created`, wraps store errors in `ErrStoreFailure`, returns validation errors unwrapped
- [x] `docker`: `buildRunCommand` uses `task.AgentImage` when set and falls back to `cfg.AgentImage` when empty; `buildEnvFlags` emits Supabase envs only for read mode with non-empty cfg
- [x] `fargate`: `selectTaskDefinition` picks reader TD for read mode (with fallback) and ignores it for code/review; `buildECSEnvVars` emits Supabase envs only for read mode with non-empty cfg
- [x] `store` (testcontainers): `CreateTask` → `GetTask` round-trips `AgentImage`; default empty value round-trips as Go zero value