### PR TITLE
Add reading-mode completion pipeline (#174)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,15 @@
 
 Backflow is a Go service that runs coding agents (Claude Code or Codex) in ephemeral containers. Tasks come in via REST API; the orchestrator provisions infrastructure, runs agents, and cleans up.
 
+Three task modes: `code` (default: clone → code → commit → PR), `review` (PR review with inline comments), and `read` (fetch a URL, summarize it via a reader agent, embed the TL;DR, store the result in the `readings` table for later similarity search).
+
+## HANDOFF.md
+
+`HANDOFF.md` at the repo root captures cross-PR tradeoffs and decisions that aren't obvious from the diff alone — what was deferred, what was unblocked for future issues, and why an alternative was rejected.
+
+- **Before writing a plan:** read `HANDOFF.md` and weigh any notes that apply to the current task. Prior decisions may constrain or inform the approach.
+- **When writing a plan:** add brief notes to `HANDOFF.md` about explicit tradeoffs decided for this change — especially any decisions the user expressed directly (e.g. "add Force now vs defer to #175"). Record the decision, the alternatives considered, and the consequence for downstream work. Keep each entry tight; this file is a ledger, not a design doc.
+
 ## Commands
 
 ```bash
@@ -61,12 +70,13 @@ Two goroutines: chi REST API on `:8080` + polling orchestrator (5s default). Thr
 ### Key modules (`internal/`)
 
 - **api/** — chi router, handlers, JSON responses, `LogFetcher` interface, `NewTask` shared task-creation helper (used by both REST handler and Discord modal), `CancelTask` and `RetryTask` shared action helpers (used by both REST handler and Discord)
-- **orchestrator/** — Poll loop (`orchestrator.go`), dispatch (`dispatch.go`), monitoring (`monitor.go`), recovery (`recovery.go`), local mode (`local.go`). Subpackages: `docker/` (Docker container management via SSM or local exec), `ec2/` (EC2 lifecycle, auto-scaler, spot interruption handler), `fargate/` (ECS/Fargate runner, CloudWatch log parsing), `s3/` (agent output upload)
-- **store/** — `Store` interface + PostgreSQL (`pgxpool`, goose migrations)
-- **models/** — `Task`, `Instance`, `AllowedSender`, and `DiscordInstall` structs with status enums. `FindFirstURL` / `InferReviewMode` auto-detect review mode when a prompt's first URL is a GitHub PR URL.
+- **orchestrator/** — Poll loop (`orchestrator.go`), dispatch (`dispatch.go`), monitoring (`monitor.go`, including `handleReadingCompletion` for read-mode tasks), recovery (`recovery.go`), local mode (`local.go`). Subpackages: `docker/` (Docker container management via SSM or local exec), `ec2/` (EC2 lifecycle, auto-scaler, spot interruption handler), `fargate/` (ECS/Fargate runner, CloudWatch log parsing), `s3/` (agent output upload)
+- **store/** — `Store` interface + PostgreSQL (`pgxpool`, goose migrations). Includes `CreateReading` / `UpsertReading` for the `readings` table.
+- **models/** — `Task`, `Instance`, `AllowedSender`, `DiscordInstall`, and `Reading` (+ `Connection`) structs with status enums. `FindFirstURL` / `InferReviewMode` auto-detect review mode when a prompt's first URL is a GitHub PR URL.
+- **embeddings/** — Thin `Embedder` interface (`Embed(ctx, text) ([]float32, error)`) with an `OpenAIEmbedder` HTTP client (no SDK). Used by the orchestrator to embed a reading's final TL;DR before writing the `readings` row.
 - **discord/** — Discord interaction handler (Ed25519 signature verification, PING/PONG, interaction routing, `/backflow create` modal for task creation, `/backflow cancel` and `/backflow retry` commands, button click handling). `HandlerActions` struct groups callback functions and role-based authorization config.
-- **config/** — Env-var config (`BACKFLOW_*` prefix), three modes (`ec2`/`local`/`fargate`). `RestrictAPI` blocks all `/api/v1/*` endpoints when `BACKFLOW_RESTRICT_API=true` (used in Fly.io deployment). `BACKFLOW_API_KEY` enables single-token API auth; otherwise `api_keys` in Postgres can back authenticated API/debug requests. `TaskDefaults(taskMode)` returns resolved defaults; `Apply(task, overrides)` fills zero-value fields using `*bool` overrides (nil = use default, non-nil = use pointed value)
-- **notify/** — `Notifier` interface, `WebhookNotifier` (HTTP POST, 3 retries, event filtering), `DiscordNotifier` (lifecycle messages in channel + per-task threads), `NoopNotifier`, `EventBus` (async fan-out delivery via buffered channel), `NewEvent` constructor with `EventOption` functional options, `MessagingNotifier` (SMS via Twilio for reply channels)
+- **config/** — Env-var config (`BACKFLOW_*` prefix), three modes (`ec2`/`local`/`fargate`). `RestrictAPI` blocks all `/api/v1/*` endpoints when `BACKFLOW_RESTRICT_API=true` (used in Fly.io deployment). `BACKFLOW_API_KEY` enables single-token API auth; otherwise `api_keys` in Postgres can back authenticated API/debug requests. `TaskDefaults(taskMode)` returns resolved defaults — for `read` mode it swaps in `ReaderImage` plus the `BACKFLOW_DEFAULT_READ_MAX_*` caps. `Apply(task, overrides)` fills zero-value fields using `*bool` overrides (nil = use default, non-nil = use pointed value)
+- **notify/** — `Notifier` interface, `WebhookNotifier` (HTTP POST, 3 retries, event filtering), `DiscordNotifier` (lifecycle messages in channel + per-task threads), `NoopNotifier`, `EventBus` (async fan-out delivery via buffered channel), `NewEvent` constructor with `EventOption` functional options (including `WithReading` for read-mode completion events), `MessagingNotifier` (SMS via Twilio for reply channels). `Event` carries `TaskMode` plus optional reading fields (`TLDR`, `NoveltyVerdict`, `Tags`, `Connections`) populated only for read-task completion events.
 - **messaging/** — `Messenger` interface, `TwilioMessenger` (outbound SMS), inbound SMS webhook handler, message parsing
 - **debug/** — `/debug/stats` handler: PID, uptime, running task count, pgxpool metrics
 
@@ -116,6 +126,30 @@ At startup, Backflow persists the install config to the `discord_installs` table
 - `BACKFLOW_SLACK_EVENTS` (comma-separated event filter)
 
 If the Slack webhook URL is set, `cmd/backflow/main.go` logs that the subscriber is not yet implemented.
+
+## Reading mode
+
+When a task's `task_mode` is `read`, the orchestrator selects `BACKFLOW_READER_IMAGE` instead of the default agent image. The reader container fetches the URL in the prompt, drafts a summary, and emits structured JSON (url/title/tldr/tags/connections/novelty_verdict/etc.) to `status.json` (and a `BACKFLOW_STATUS_JSON:` log line for Fargate).
+
+On completion, the orchestrator's `handleReadingCompletion` helper (in `internal/orchestrator/monitor.go`) runs synchronously:
+
+1. Parses the reading-specific fields off `ContainerStatus`.
+2. Calls `embeddings.Embedder.Embed(ctx, tldr)` to embed the final TL;DR (re-embedded by the orchestrator, not reused from the agent — the agent's draft TL;DR can be refined after similarity lookup).
+3. Writes the row via `store.CreateReading`, or `store.UpsertReading` when `task.Force == true`.
+4. Emits `task.completed` with `WithReading(tldr, verdict, tags, connections)`.
+
+If the embedding API call or the DB write fails, the task is marked `failed` rather than silently `completed`, and `task.failed` is emitted. If `embedder` is nil (no `OPENAI_API_KEY` configured), reading tasks fail at completion.
+
+The reading agent image and reader-side shell scripts live in `docker/reader/`; see `docs/supabase-setup.md` for the PostgREST-backed similarity-search path the agent uses during its session.
+
+Reading-mode env vars:
+
+- `BACKFLOW_READER_IMAGE` — Docker image for reading-mode containers
+- `BACKFLOW_DEFAULT_READ_MAX_BUDGET` / `BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC` / `BACKFLOW_DEFAULT_READ_MAX_TURNS` — Tighter defaults applied by `TaskDefaults("read")`
+- `OPENAI_API_KEY` — Required for the orchestrator's embeddings client (and for the reader container's `read-embed.sh`)
+- `SUPABASE_URL` / `SUPABASE_ANON_KEY` — Passed to reader containers for PostgREST similarity search (see `docs/supabase-setup.md`)
+
+The `tasks` table carries a `force` boolean column. The API input for force is not wired yet (tracked separately) — today `task.Force` is set by the orchestrator only when explicitly populated through other creation paths.
 
 ## Harnesses
 
@@ -173,7 +207,7 @@ Do not record default values for config or env vars in documentation. Defaults c
 
 ## Input validation
 
-Environment variable keys passed via the `env_vars` field must match POSIX naming rules (`^[A-Za-z_][A-Za-z0-9_]*$`) and must not override reserved system keys (e.g. `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `TASK_ID`). See `reservedEnvVarKeys` in `internal/models/task.go` for the full list. All user-supplied text fields are validated to reject null bytes (PostgreSQL text columns reject them).
+Environment variable keys passed via the `env_vars` field must match POSIX naming rules (`^[A-Za-z_][A-Za-z0-9_]*$`) and must not override reserved system keys (e.g. `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `TASK_ID`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`). See `reservedEnvVarKeys` in `internal/models/task.go` for the full list. All user-supplied text fields are validated to reject null bytes (PostgreSQL text columns reject them).
 
 In Docker mode, secrets (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GITHUB_TOKEN`) are passed via `--env-file` rather than inline in the command string. In Fargate mode, reserved keys are blocked at validation time.
 
@@ -210,4 +244,4 @@ Additional docs in `docs/`:
 - `sizing.md` — EC2 instance sizing and container density guide
 - `setup-ci.md` — GitHub Actions CI/CD setup for agent image builds
 - `fly-setup.md` — Fly.io deployment setup and configuration
-- `supabase-setup.md` — Supabase project setup, reader Data API configuration, and key model
+- `supabase-setup.md` — Supabase project setup, `readings` table, `reader` schema for PostgREST, and the publishable-key model used by the reader container

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,79 +1,11 @@
-# Reading Completion Pipeline (#174) — Handoff Notes
+# HANDOFF.md
 
-## Context
+Ledger of cross-PR tradeoffs. Each entry: decision → consequence for downstream work.
 
-This PR implements issue #174: the orchestrator-side pipeline for handling reader-task completion. Decisions that expand or contract the scope are recorded below so downstream issues (#175, #177) don't re-litigate them.
+## #174 — Reading completion pipeline
 
-## Decisions made in this PR
-
-### 1. `Task.Force` added here (unblocks #175)
-
-The acceptance criteria call for `UpsertReading` when `task.Force == true`, but the `Force` field did not exist on the `Task` model. We added:
-
-- `Force bool` on `models.Task`
-- `force BOOLEAN NOT NULL DEFAULT false` column on the `tasks` table via a new goose migration
-- Updates to `postgres.go` scan/insert
-
-**Consequence for #175 (REST API reading task creation):** the backend now persists `Force`. #175 only needs to wire `Force *bool` onto `CreateTaskRequest` and copy it into the `Task` at creation time — no schema work required.
-
-**Alternative considered:** reading force from a field the reader agent writes to `status.json`. Rejected because it couples force semantics to agent output rather than caller intent, and because force affects the agent's own duplicate-check behavior (it needs to know up-front).
-
-### 2. `Event.TaskMode` added here (unblocks #177)
-
-`NewEvent` did not previously copy `task.TaskMode` onto the `Event`. We added `TaskMode` to the `Event` struct and populate it in `NewEvent`. This costs one line and lets `DiscordNotifier` branch on `event.TaskMode == "read"` in #177 without further plumbing.
-
-**Consequence for #177 (Discord reading completion embed):** `event.TaskMode` is guaranteed set. The new reading fields on `Event` (`TLDR`, `NoveltyVerdict`, `Tags`, `Connections`) are also populated for reading-task completion events. #177 is now purely a formatting change inside `DiscordNotifier`.
-
-### 3. Embeddings client is single-shot (no retries)
-
-`OpenAIEmbedder.Embed` makes one HTTP call and returns the error. Rationale:
-
-- Matches the orchestrator's existing pattern of fail-fast external calls.
-- Failures surface as task failures, which the higher-level task retry system can handle.
-- Keeps the client trivially testable and easy to reason about.
-
-**Consequence for future work:** if transient OpenAI 429/5xx rates become a problem, retries can be added inside the client without changing the interface. The `Embedder` interface (`Embed(ctx, text) ([]float32, error)`) is deliberately narrow.
-
-### 4. `RawOutput` is the marshaled `AgentStatus`
-
-Rather than adding a separate `raw_output` field that the agent writes, the orchestrator marshals the full parsed `AgentStatus` to `json.RawMessage` when constructing the `Reading`. This is lossless for typed fields, avoids a round-trip through the agent image, and lets the agent prompt evolve without adding new schema fields.
-
-**Consequence:** if the agent starts emitting fields we don't parse yet, they won't be captured in `raw_output`. Acceptable trade-off — `status.json` is the agent's public interface, and extending `AgentStatus` to pick up a new field is a two-line change.
-
-## Things we did NOT do (scope kept narrow)
-
-### Discord reading embed formatting — deferred to #177
-
-`DiscordNotifier` still uses the existing code/review embed shape for reading completions. The data is present on the event; #177 adds the reading-specific format.
-
-### API-level `force` wiring — deferred to #175
-
-`CreateTaskRequest` has no `force` field yet. Submitting `{"force": true}` today has no effect. #175 adds the API input and the assignment `task.Force = *req.Force` at creation time.
-
-### Reading cancellation / interruption semantics — deferred
-
-Reading tasks use the same cancellation / interruption flow as code tasks. No reading row is written until completion, so interrupted reading tasks leave no orphans in the `readings` table. Intentionally simple; revisit only if partial readings become a feature request.
-
-### `GetReadingByURL` / reading query methods — not added
-
-`UpsertReading` handles the force-re-read case via `ON CONFLICT (url)`. No code path in this PR reads readings back from the DB, so adding accessors would be speculative. Add when a consumer appears.
-
-### `SUPABASE_READER_KEY` config — not added
-
-The PRD mentions a custom `backflow_reader` JWT. The repo currently uses `SUPABASE_ANON_KEY`. Aligning the two is a separate Supabase-side task (role + JWT minting) and has no bearing on the completion pipeline.
-
-## Test coverage
-
-All new code is covered by unit tests with mocked dependencies:
-
-- `internal/embeddings/` — `httptest.NewServer` stubs OpenAI, verifies request shape, response parsing, and error handling (`TestOpenAIEmbedder_PostsCorrectPayload`, `_ParsesEmbedding`, `_ReturnsErrorOnNon200`, `_EmptyData`).
-- `internal/orchestrator/monitor_test.go` — mocked store + mocked embedder verifies success, force upsert, embed failure, and store failure paths for reading completion (`TestHandleCompletion_ReadSuccess_EmbedsAndCreatesReading`, `_ReadForce_CallsUpsertReading`, `_ReadEmbedFailure_MarksTaskFailed`, `_ReadStoreFailure_MarksTaskFailed`).
-- `internal/orchestrator/runner_test.go` — JSON round-trip for the new `AgentStatus` reading fields.
-- `internal/store/postgres_test.go` — `Force` column round-trip against real pgvector Postgres via testcontainers.
-- `internal/notify/bus_test.go` — `WithReading` option populates reading fields; `NewEvent` copies `TaskMode` from task.
-
-End-to-end validation against real OpenAI + Supabase + Fargate is out of scope per the PRD's "explicitly not tested" list. Run a real reader task post-deploy to validate the full chain.
-
-## Pre-existing flake
-
-`TestFakeAgentTimeout` in `test/blackbox/fake-agent/fake_agent_test.go` fails on `main` too — the timeout outcome's container sometimes exits 0 before the 2-second sleep in the test. Unrelated to this work; left alone.
+- **`Task.Force` added here, not #175.** `models.Task` gains `Force bool` + migration `012_task_force.sql`. #175 is now pure API wiring — add `Force *bool` to `CreateTaskRequest` and copy it in at creation time, no schema work.
+- **`Event.TaskMode` populated in `NewEvent`.** One-line change. #177's Discord reading embed can branch on `event.TaskMode == "read"` without further plumbing. Reading fields (`TLDR`, `NoveltyVerdict`, `Tags`, `Connections`) are also already on the event for read-task completions.
+- **Embeddings client is single-shot, no retries.** Failures surface as task failures; higher-level retry handles transients. Add retries later inside `OpenAIEmbedder` without changing the `Embedder` interface if 429/5xx rates become an issue.
+- **`reading.raw_output` is the marshaled `AgentStatus`, not a separate agent field.** Lossless for typed fields; adding new agent output requires extending `AgentStatus` (two lines).
+- **Deferred:** Discord reading embed formatting (#177), API-level `force` wiring (#175), `GetReadingByURL`/reader accessors (no consumer yet), `SUPABASE_READER_KEY` custom JWT (dead-ended on Supabase side — using publishable key via `SUPABASE_ANON_KEY`, see `docs/supabase-setup.md`).

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,79 @@
+# Reading Completion Pipeline (#174) — Handoff Notes
+
+## Context
+
+This PR implements issue #174: the orchestrator-side pipeline for handling reader-task completion. Decisions that expand or contract the scope are recorded below so downstream issues (#175, #177) don't re-litigate them.
+
+## Decisions made in this PR
+
+### 1. `Task.Force` added here (unblocks #175)
+
+The acceptance criteria call for `UpsertReading` when `task.Force == true`, but the `Force` field did not exist on the `Task` model. We added:
+
+- `Force bool` on `models.Task`
+- `force BOOLEAN NOT NULL DEFAULT false` column on the `tasks` table via a new goose migration
+- Updates to `postgres.go` scan/insert
+
+**Consequence for #175 (REST API reading task creation):** the backend now persists `Force`. #175 only needs to wire `Force *bool` onto `CreateTaskRequest` and copy it into the `Task` at creation time — no schema work required.
+
+**Alternative considered:** reading force from a field the reader agent writes to `status.json`. Rejected because it couples force semantics to agent output rather than caller intent, and because force affects the agent's own duplicate-check behavior (it needs to know up-front).
+
+### 2. `Event.TaskMode` added here (unblocks #177)
+
+`NewEvent` did not previously copy `task.TaskMode` onto the `Event`. We added `TaskMode` to the `Event` struct and populate it in `NewEvent`. This costs one line and lets `DiscordNotifier` branch on `event.TaskMode == "read"` in #177 without further plumbing.
+
+**Consequence for #177 (Discord reading completion embed):** `event.TaskMode` is guaranteed set. The new reading fields on `Event` (`TLDR`, `NoveltyVerdict`, `Tags`, `Connections`) are also populated for reading-task completion events. #177 is now purely a formatting change inside `DiscordNotifier`.
+
+### 3. Embeddings client is single-shot (no retries)
+
+`OpenAIEmbedder.Embed` makes one HTTP call and returns the error. Rationale:
+
+- Matches the orchestrator's existing pattern of fail-fast external calls.
+- Failures surface as task failures, which the higher-level task retry system can handle.
+- Keeps the client trivially testable and easy to reason about.
+
+**Consequence for future work:** if transient OpenAI 429/5xx rates become a problem, retries can be added inside the client without changing the interface. The `Embedder` interface (`Embed(ctx, text) ([]float32, error)`) is deliberately narrow.
+
+### 4. `RawOutput` is the marshaled `AgentStatus`
+
+Rather than adding a separate `raw_output` field that the agent writes, the orchestrator marshals the full parsed `AgentStatus` to `json.RawMessage` when constructing the `Reading`. This is lossless for typed fields, avoids a round-trip through the agent image, and lets the agent prompt evolve without adding new schema fields.
+
+**Consequence:** if the agent starts emitting fields we don't parse yet, they won't be captured in `raw_output`. Acceptable trade-off — `status.json` is the agent's public interface, and extending `AgentStatus` to pick up a new field is a two-line change.
+
+## Things we did NOT do (scope kept narrow)
+
+### Discord reading embed formatting — deferred to #177
+
+`DiscordNotifier` still uses the existing code/review embed shape for reading completions. The data is present on the event; #177 adds the reading-specific format.
+
+### API-level `force` wiring — deferred to #175
+
+`CreateTaskRequest` has no `force` field yet. Submitting `{"force": true}` today has no effect. #175 adds the API input and the assignment `task.Force = *req.Force` at creation time.
+
+### Reading cancellation / interruption semantics — deferred
+
+Reading tasks use the same cancellation / interruption flow as code tasks. No reading row is written until completion, so interrupted reading tasks leave no orphans in the `readings` table. Intentionally simple; revisit only if partial readings become a feature request.
+
+### `GetReadingByURL` / reading query methods — not added
+
+`UpsertReading` handles the force-re-read case via `ON CONFLICT (url)`. No code path in this PR reads readings back from the DB, so adding accessors would be speculative. Add when a consumer appears.
+
+### `SUPABASE_READER_KEY` config — not added
+
+The PRD mentions a custom `backflow_reader` JWT. The repo currently uses `SUPABASE_ANON_KEY`. Aligning the two is a separate Supabase-side task (role + JWT minting) and has no bearing on the completion pipeline.
+
+## Test coverage
+
+All new code is covered by unit tests with mocked dependencies:
+
+- `internal/embeddings/` — `httptest.NewServer` stubs OpenAI, verifies request shape, response parsing, and error handling (`TestOpenAIEmbedder_PostsCorrectPayload`, `_ParsesEmbedding`, `_ReturnsErrorOnNon200`, `_EmptyData`).
+- `internal/orchestrator/monitor_test.go` — mocked store + mocked embedder verifies success, force upsert, embed failure, and store failure paths for reading completion (`TestHandleCompletion_ReadSuccess_EmbedsAndCreatesReading`, `_ReadForce_CallsUpsertReading`, `_ReadEmbedFailure_MarksTaskFailed`, `_ReadStoreFailure_MarksTaskFailed`).
+- `internal/orchestrator/runner_test.go` — JSON round-trip for the new `AgentStatus` reading fields.
+- `internal/store/postgres_test.go` — `Force` column round-trip against real pgvector Postgres via testcontainers.
+- `internal/notify/bus_test.go` — `WithReading` option populates reading fields; `NewEvent` copies `TaskMode` from task.
+
+End-to-end validation against real OpenAI + Supabase + Fargate is out of scope per the PRD's "explicitly not tested" list. Run a real reader task post-deploy to validate the full chain.
+
+## Pre-existing flake
+
+`TestFakeAgentTimeout` in `test/blackbox/fake-agent/fake_agent_test.go` fails on `main` too — the timeout outcome's container sometimes exits 0 before the 2-second sleep in the test. Unrelated to this work; left alone.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Agent orchestrator that runs coding agents (Claude Code or Codex) in ephemeral containers. POST a task (repo + prompt), get back a branch with commits and a PR. Three modes: EC2 spot instances, local Docker, or ECS Fargate.
 
+Also supports a `read` task mode that runs a dedicated reader image against a URL, summarizes it, embeds the TL;DR, and stores the result in a `readings` table for similarity search. See [CLAUDE.md](CLAUDE.md#reading-mode) and [docs/supabase-setup.md](docs/supabase-setup.md).
+
 ## Prerequisites
 
 - Go 1.25+
@@ -143,7 +145,7 @@ curl -X POST http://localhost:8080/api/v1/tasks \
 |-------|------|-------------|
 | `repo_url` | string | **Required.** Repository URL |
 | `prompt` | string | **Required for code mode.** Agent instructions |
-| `task_mode` | string | `code` or `review`; auto-detected from PR URLs in prompt when unset |
+| `task_mode` | string | `code`, `review`, or `read`; auto-detected from PR URLs in prompt when unset |
 | `harness` | string | `codex` or `claude_code` |
 | `model` | string | Model override (per-harness; see server config) |
 | `effort` | string | `low`, `medium`, `high`, or `xhigh` |
@@ -307,12 +309,25 @@ All config via environment variables or `.env` file. See `.env.example` for the 
 |----------|---------|-------------|
 | `BACKFLOW_MODE` | `ec2` | `ec2`, `local`, or `fargate` |
 | `ANTHROPIC_API_KEY` | | Required |
-| `OPENAI_API_KEY` | | Required for `codex` harness |
+| `OPENAI_API_KEY` | | Required for `codex` harness; also required for reading-mode completion (embedding the TL;DR) |
 | `GITHUB_TOKEN` | | For cloning private repos and creating PRs |
 | `BACKFLOW_LISTEN_ADDR` | `:8080` | Server listen address |
 | `BACKFLOW_DATABASE_URL` | | PostgreSQL connection string (Supabase session pooler recommended) |
 | `BACKFLOW_POLL_INTERVAL_SEC` | `5` | Orchestrator poll interval (seconds) |
 | `BACKFLOW_S3_BUCKET` | | S3 bucket for agent output and large prompt offload |
+
+### Reading Mode
+
+| Variable | Description |
+|----------|-------------|
+| `BACKFLOW_READER_IMAGE` | Docker image used for `task_mode=read` containers |
+| `BACKFLOW_DEFAULT_READ_MAX_BUDGET` | Budget cap for reading tasks |
+| `BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC` | Runtime cap for reading tasks |
+| `BACKFLOW_DEFAULT_READ_MAX_TURNS` | Max turns for reading tasks |
+| `SUPABASE_URL` | Supabase project URL passed to reader containers |
+| `SUPABASE_ANON_KEY` | Supabase publishable key (`sb_publishable_...`) passed to reader containers for PostgREST calls |
+
+See [docs/supabase-setup.md](docs/supabase-setup.md) for the `readings` schema, `reader` PostgREST schema, and key model.
 
 ### Agent Defaults
 

--- a/cmd/backflow/main.go
+++ b/cmd/backflow/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/backflow-labs/backflow/internal/config"
 	"github.com/backflow-labs/backflow/internal/debug"
 	"github.com/backflow-labs/backflow/internal/discord"
+	"github.com/backflow-labs/backflow/internal/embeddings"
 	"github.com/backflow-labs/backflow/internal/messaging"
 	"github.com/backflow-labs/backflow/internal/models"
 	"github.com/backflow-labs/backflow/internal/notify"
@@ -147,7 +148,12 @@ func main() {
 		spot = orchec2.NewSpotHandler(db, ec2mgr, bus)
 	}
 
-	orch := orchestrator.New(db, cfg, bus, runner, scaler, spot, s3Uploader)
+	var embedder embeddings.Embedder
+	if cfg.OpenAIAPIKey != "" {
+		embedder = embeddings.NewOpenAIEmbedder(cfg.OpenAIAPIKey, "", nil)
+	}
+
+	orch := orchestrator.New(db, cfg, bus, runner, scaler, spot, s3Uploader, embedder)
 
 	router := api.NewServer(db, cfg, orch.Docker(), bus)
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -12,7 +12,7 @@ Stores agent tasks submitted via the REST API.
 |--------|------|---------|-------------|
 | `id` | `TEXT` | — | **Primary key.** ULID with `bf_` prefix (e.g. `bf_01KKQW82994E87Z99QVEMBN8V0`). |
 | `status` | `TEXT` | `'pending'` | Task lifecycle state. One of: `pending`, `provisioning`, `running`, `completed`, `failed`, `interrupted`, `cancelled`, `recovering`. |
-| `task_mode` | `TEXT` | `'code'` | Task mode. `code` (default) or `review` (PR review). |
+| `task_mode` | `TEXT` | `'code'` | Task mode. One of: `code` (default), `review` (PR review), `read` (URL summarization), or `auto` (Prep stage infers code vs review). |
 | `harness` | `TEXT` | `'claude_code'` | Agent CLI harness. `claude_code` (default) or `codex`. |
 | `repo_url` | `TEXT` | — | Git repository URL to clone (required). |
 | `branch` | `TEXT` | `''` | Branch to check out before running the agent. |
@@ -43,6 +43,8 @@ Stores agent tasks submitted via the REST API.
 | `error` | `TEXT` | `''` | Error message if the task failed. |
 | `ready_for_retry` | `BOOLEAN` | `false` | Whether the task is ready for user retry. Set `true` after container cleanup completes (for failed/cancelled/interrupted tasks under the retry cap). Reset to `false` on requeue. |
 | `reply_channel` | `TEXT` | `''` | Messaging reply channel (e.g. `sms:+15551234567`). Set when task is created via SMS. |
+| `agent_image` | `TEXT` | `''` | Docker image the orchestrator used for this task's container. Populated at creation time — code/review tasks get the default agent image; read tasks get `BACKFLOW_READER_IMAGE`. Not user-settable via the API. |
+| `force` | `BOOLEAN` | `false` | For reading tasks, skip the exact-URL duplicate check and upsert the existing `readings` row on completion. Ignored for `code`/`review` tasks. |
 | `created_at` | `TIMESTAMPTZ` | `now()` | When the task was created. |
 | `updated_at` | `TIMESTAMPTZ` | `now()` | Last modification time. |
 | `started_at` | `TIMESTAMPTZ` | `NULL` | When the agent container started. Nullable. |
@@ -99,6 +101,43 @@ Stores bearer tokens used to authenticate API and debug requests.
 
 **Indexes:**
 - `idx_api_keys_expires_at` on `expires_at` — used to support expiration checks and cleanup.
+
+### `readings`
+
+Structured output of completed `task_mode=read` tasks. Populated by the orchestrator's `handleReadingCompletion` helper.
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `id` | `TEXT` | — | **Primary key.** ULID with `bf_` prefix. |
+| `task_id` | `TEXT` | — | Foreign key to `tasks(id)`, `ON DELETE CASCADE`. |
+| `url` | `TEXT` | — | Source URL. `UNIQUE` index for duplicate lookups and upsert. |
+| `title` | `TEXT` | `''` | Page title as reported by the reader agent. |
+| `tldr` | `TEXT` | `''` | Short summary. The orchestrator embeds this text to populate `embedding`. |
+| `tags` | `TEXT[]` | `'{}'` | Topic tags from the agent. |
+| `keywords` | `TEXT[]` | `'{}'` | Salient keywords. |
+| `people` | `TEXT[]` | `'{}'` | People named in the article. |
+| `orgs` | `TEXT[]` | `'{}'` | Organizations named in the article. |
+| `novelty_verdict` | `TEXT` | `''` | Agent's judgment relative to existing readings (`new`, `nothing new`, etc.). |
+| `connections` | `JSONB` | `'[]'` | Array of `{reading_id, reason}` pointing at similar prior readings. |
+| `summary` | `TEXT` | `''` | Full markdown summary. |
+| `raw_output` | `JSONB` | `'{}'` | Lossless JSON of the agent's parsed `status.json`, kept for future re-normalization. |
+| `embedding` | `vector(1536)` | `NULL` | OpenAI `text-embedding-3-small` vector of the final TL;DR. Embedded by the orchestrator, not the agent. |
+| `is_available` | `BOOLEAN` | `true` | When `false`, the row is hidden from the Supabase Data API (RLS policy + RPC filter). Used for moderation / soft-delete. |
+| `created_at` | `TIMESTAMPTZ` | `now()` | When the reading was stored. |
+
+**Indexes:**
+- Unique `idx_readings_url` on `url` — duplicate detection and upsert.
+- HNSW `idx_readings_embedding` on `embedding` using `vector_cosine_ops` — similarity search.
+
+**RLS:** Enabled on this table. Policy `readings_anon_select` grants `SELECT TO anon USING (is_available = true)`. All writes go through the application role via `BACKFLOW_DATABASE_URL`.
+
+**Related objects (migration `011_readings.sql`):**
+- Schema `reader` — exposes a narrow view and RPC via Supabase PostgREST. Intended as the only schema in the Supabase Data API → Exposed schemas list.
+- View `reader.readings` (`security_invoker = true`) projecting only `id, url, title, tldr`.
+- Function `reader.match_readings(query_embedding vector(1536), match_count int)` returning `(id, title, tldr, url, similarity)` ordered by cosine similarity, executable by `anon`.
+- RLS is also enabled on `tasks`, `instances`, `allowed_senders`, `discord_installs`, `discord_task_threads`, and `api_keys` as deny-all for non-owner roles.
+
+See [supabase-setup.md](supabase-setup.md) for how the reader container authenticates to PostgREST and why there is intentionally no `SUPABASE_READER_KEY`.
 
 ## Status Lifecycles
 

--- a/internal/embeddings/embeddings.go
+++ b/internal/embeddings/embeddings.go
@@ -1,0 +1,80 @@
+// Package embeddings provides a minimal client for text embedding APIs.
+package embeddings
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const errBodySnippetMax = 256
+
+// Embedder turns text into a dense vector.
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+}
+
+const openAIModel = "text-embedding-3-small"
+
+// OpenAIEmbedder calls the OpenAI embeddings REST API.
+type OpenAIEmbedder struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewOpenAIEmbedder constructs an embedder. baseURL defaults to the public
+// OpenAI endpoint when empty; httpClient defaults to http.DefaultClient.
+func NewOpenAIEmbedder(apiKey, baseURL string, httpClient *http.Client) *OpenAIEmbedder {
+	if baseURL == "" {
+		baseURL = "https://api.openai.com"
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &OpenAIEmbedder{apiKey: apiKey, baseURL: baseURL, httpClient: httpClient}
+}
+
+func (e *OpenAIEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	body, err := json.Marshal(map[string]string{
+		"model": openAIModel,
+		"input": text,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal embeddings request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/v1/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build embeddings request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+e.apiKey)
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("call embeddings API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, errBodySnippetMax))
+		return nil, fmt.Errorf("embeddings API returned %d: %s", resp.StatusCode, string(snippet))
+	}
+
+	var out struct {
+		Data []struct {
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode embeddings response: %w", err)
+	}
+	if len(out.Data) == 0 {
+		return nil, fmt.Errorf("embeddings response contained no data")
+	}
+	return out.Data[0].Embedding, nil
+}

--- a/internal/embeddings/embeddings_test.go
+++ b/internal/embeddings/embeddings_test.go
@@ -1,0 +1,109 @@
+package embeddings
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOpenAIEmbedder_PostsCorrectPayload(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotAuth   string
+		gotBody   map[string]any
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1]}]}`))
+	}))
+	defer srv.Close()
+
+	e := NewOpenAIEmbedder("test-key", srv.URL, srv.Client())
+	_, _ = e.Embed(context.Background(), "hello")
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/v1/embeddings" {
+		t.Errorf("path = %q, want /v1/embeddings", gotPath)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Errorf("auth = %q, want %q", gotAuth, "Bearer test-key")
+	}
+	if gotBody["model"] != "text-embedding-3-small" {
+		t.Errorf("body.model = %v, want text-embedding-3-small", gotBody["model"])
+	}
+	if gotBody["input"] != "hello" {
+		t.Errorf("body.input = %v, want hello", gotBody["input"])
+	}
+}
+
+func TestOpenAIEmbedder_ParsesEmbedding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1,0.2,0.3]}]}`))
+	}))
+	defer srv.Close()
+
+	e := NewOpenAIEmbedder("test-key", srv.URL, srv.Client())
+	got, err := e.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+
+	want := []float32{0.1, 0.2, 0.3}
+	if len(got) != len(want) {
+		t.Fatalf("len(embedding) = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("embedding[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestOpenAIEmbedder_ReturnsErrorOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer srv.Close()
+
+	e := NewOpenAIEmbedder("test-key", srv.URL, srv.Client())
+	_, err := e.Embed(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("Embed: want error for 429, got nil")
+	}
+	if !strings.Contains(err.Error(), "429") {
+		t.Errorf("error = %q, want it to mention 429", err.Error())
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("error = %q, want it to include body snippet", err.Error())
+	}
+}
+
+func TestOpenAIEmbedder_EmptyData(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	e := NewOpenAIEmbedder("test-key", srv.URL, srv.Client())
+	_, err := e.Embed(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("Embed: want error for empty data, got nil")
+	}
+}

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -54,6 +54,7 @@ type Task struct {
 	Model           string            `json:"model,omitempty"`
 	Effort          string            `json:"effort,omitempty"`
 	AgentImage      string            `json:"agent_image,omitempty"`
+	Force           bool              `json:"force,omitempty"`
 	MaxBudgetUSD    float64           `json:"max_budget_usd,omitempty"`
 	MaxRuntimeSec   int               `json:"max_runtime_sec,omitempty"`
 	MaxTurns        int               `json:"max_turns,omitempty"`

--- a/internal/notify/bus_test.go
+++ b/internal/notify/bus_test.go
@@ -150,6 +150,35 @@ func TestNewEvent_WithContainerStatus(t *testing.T) {
 	}
 }
 
+func TestNewEvent_CopiesTaskMode(t *testing.T) {
+	task := &models.Task{ID: "bf_1", TaskMode: models.TaskModeRead}
+	event := NewEvent(EventTaskCompleted, task)
+	if event.TaskMode != models.TaskModeRead {
+		t.Errorf("TaskMode = %q, want %q", event.TaskMode, models.TaskModeRead)
+	}
+}
+
+func TestNewEvent_WithReading_PopulatesFields(t *testing.T) {
+	task := &models.Task{ID: "bf_1", TaskMode: models.TaskModeRead}
+	tags := []string{"ai", "systems"}
+	conns := []models.Connection{{ReadingID: "bf_other", Reason: "same topic"}}
+
+	event := NewEvent(EventTaskCompleted, task, WithReading("short summary", "new", tags, conns))
+
+	if event.TLDR != "short summary" {
+		t.Errorf("TLDR = %q", event.TLDR)
+	}
+	if event.NoveltyVerdict != "new" {
+		t.Errorf("NoveltyVerdict = %q", event.NoveltyVerdict)
+	}
+	if len(event.Tags) != 2 || event.Tags[0] != "ai" {
+		t.Errorf("Tags = %v", event.Tags)
+	}
+	if len(event.Connections) != 1 || event.Connections[0].ReadingID != "bf_other" {
+		t.Errorf("Connections = %+v", event.Connections)
+	}
+}
+
 // --- EventBus tests ---
 
 func TestEventBus_FanOutDelivery(t *testing.T) {

--- a/internal/notify/event.go
+++ b/internal/notify/event.go
@@ -32,11 +32,22 @@ func WithContainerStatus(prURL, message, agentLogTail string) EventOption {
 	}
 }
 
+// WithReading sets reading-specific fields on a task completion event.
+func WithReading(tldr, noveltyVerdict string, tags []string, connections []models.Connection) EventOption {
+	return func(e *Event) {
+		e.TLDR = tldr
+		e.NoveltyVerdict = noveltyVerdict
+		e.Tags = tags
+		e.Connections = connections
+	}
+}
+
 // NewEvent constructs an Event from a task, populating core fields.
 func NewEvent(eventType EventType, task *models.Task, opts ...EventOption) Event {
 	e := Event{
 		Type:         eventType,
 		TaskID:       task.ID,
+		TaskMode:     task.TaskMode,
 		RepoURL:      task.RepoURL,
 		Prompt:       task.Prompt,
 		ReplyChannel: task.ReplyChannel,

--- a/internal/notify/webhook.go
+++ b/internal/notify/webhook.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/backflow-labs/backflow/internal/models"
 	"github.com/rs/zerolog/log"
 )
 
@@ -28,6 +29,7 @@ const (
 type Event struct {
 	Type              EventType `json:"event"`
 	TaskID            string    `json:"task_id"`
+	TaskMode          string    `json:"task_mode,omitempty"`
 	RepoURL           string    `json:"repo_url,omitempty"`
 	Prompt            string    `json:"prompt,omitempty"`
 	Message           string    `json:"message,omitempty"`
@@ -37,6 +39,12 @@ type Event struct {
 	ReadyForRetry     bool      `json:"ready_for_retry,omitempty"`
 	RetryLimitReached bool      `json:"retry_limit_reached,omitempty"`
 	Timestamp         time.Time `json:"timestamp"`
+
+	// Reading-mode fields, populated only for read-task completion events.
+	TLDR           string              `json:"tldr,omitempty"`
+	NoveltyVerdict string              `json:"novelty_verdict,omitempty"`
+	Tags           []string            `json:"tags,omitempty"`
+	Connections    []models.Connection `json:"connections,omitempty"`
 }
 
 // Emitter emits task lifecycle events.

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -48,6 +48,10 @@ func (o *Orchestrator) dispatchPending(ctx context.Context) {
 // dispatch assigns a task to an available instance, starts the container,
 // and transitions the task from pending → provisioning → running.
 func (o *Orchestrator) dispatch(ctx context.Context, task *models.Task) error {
+	if task.TaskMode == models.TaskModeRead && o.embedder == nil {
+		return fmt.Errorf("cannot dispatch read task: no embedder configured (set OPENAI_API_KEY)")
+	}
+
 	instance, err := o.findAvailableInstance(ctx)
 	if errors.Is(err, errNoCapacity) {
 		o.scaler.RequestScaleUp(ctx)

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/backflow-labs/backflow/internal/models"
@@ -394,6 +395,47 @@ func TestDispatch_FindInstanceDBError(t *testing.T) {
 	// A real DB error should propagate, not be silently treated as no-capacity
 	if err == nil {
 		t.Fatal("expected error from dispatch when ListInstances fails, got nil")
+	}
+}
+
+func TestDispatch_ReadTaskWithoutEmbedder_Fails(t *testing.T) {
+	s := newMockStore()
+	s.CreateInstance(context.Background(), newLocalInstance())
+	task := &models.Task{
+		ID:       "bf_read_no_embedder",
+		Status:   models.TaskStatusPending,
+		TaskMode: models.TaskModeRead,
+		Prompt:   "https://example.com/post",
+	}
+	s.CreateTask(context.Background(), task)
+
+	bus, _ := newTestBus()
+	defer bus.Close()
+	mock := &mockDockerManager{
+		runAgentID:     "cont-should-not-run",
+		inspectResults: map[string]ContainerStatus{},
+	}
+	// No embedder configured.
+	o := newTestOrchestrator(s, bus, withDocker(mock))
+
+	task, _ = s.GetTask(context.Background(), "bf_read_no_embedder")
+	err := o.dispatch(context.Background(), task)
+	if err == nil {
+		t.Fatal("expected error from dispatch when read task has no embedder")
+	}
+	if !strings.Contains(err.Error(), "embedder") {
+		t.Errorf("error = %q, want mention of embedder", err.Error())
+	}
+
+	got, _ := s.GetTask(context.Background(), "bf_read_no_embedder")
+	if got.ContainerID != "" {
+		t.Errorf("ContainerID = %q, want empty (no container should start)", got.ContainerID)
+	}
+	if got.Status == models.TaskStatusRunning {
+		t.Errorf("task should not be running, got %q", got.Status)
+	}
+	if o.running != 0 {
+		t.Errorf("running = %d, want 0", o.running)
 	}
 }
 

--- a/internal/orchestrator/docker/docker.go
+++ b/internal/orchestrator/docker/docker.go
@@ -303,6 +303,16 @@ func (m *Manager) enrichFromStatusJSON(ctx context.Context, instanceID, containe
 	status.RepoURL = agent.RepoURL
 	status.TargetBranch = agent.TargetBranch
 	status.TaskMode = agent.TaskMode
+	status.URL = agent.URL
+	status.Title = agent.Title
+	status.TLDR = agent.TLDR
+	status.Tags = agent.Tags
+	status.Keywords = agent.Keywords
+	status.People = agent.People
+	status.Orgs = agent.Orgs
+	status.NoveltyVerdict = agent.NoveltyVerdict
+	status.Connections = agent.Connections
+	status.SummaryMarkdown = agent.SummaryMarkdown
 	if agent.Error != "" {
 		status.Error = agent.Error
 	}

--- a/internal/orchestrator/fargate/fargate.go
+++ b/internal/orchestrator/fargate/fargate.go
@@ -195,6 +195,16 @@ func (m *Manager) InspectContainer(ctx context.Context, _, containerID string) (
 			status.RepoURL = agent.RepoURL
 			status.TargetBranch = agent.TargetBranch
 			status.TaskMode = agent.TaskMode
+			status.URL = agent.URL
+			status.Title = agent.Title
+			status.TLDR = agent.TLDR
+			status.Tags = agent.Tags
+			status.Keywords = agent.Keywords
+			status.People = agent.People
+			status.Orgs = agent.Orgs
+			status.NoveltyVerdict = agent.NoveltyVerdict
+			status.Connections = agent.Connections
+			status.SummaryMarkdown = agent.SummaryMarkdown
 			if agent.Error != "" {
 				status.Error = agent.Error
 			}

--- a/internal/orchestrator/helpers_test.go
+++ b/internal/orchestrator/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/backflow-labs/backflow/internal/config"
+	"github.com/backflow-labs/backflow/internal/embeddings"
 	"github.com/backflow-labs/backflow/internal/models"
 	"github.com/backflow-labs/backflow/internal/notify"
 	"github.com/backflow-labs/backflow/internal/store"
@@ -32,6 +33,12 @@ type mockStore struct {
 	markReadyForRetryErr   error
 	decrementContainersErr error
 	listInstancesErr       error
+	createReadingErr       error
+	upsertReadingErr       error
+
+	// Recorded reading calls.
+	createdReadings  []models.Reading
+	upsertedReadings []models.Reading
 }
 
 func newMockStore() *mockStore {
@@ -343,9 +350,29 @@ func (s *mockStore) WithTx(_ context.Context, fn func(store.Store) error) error 
 	return fn(s)
 }
 
-func (s *mockStore) CreateReading(context.Context, *models.Reading) error { return nil }
-func (s *mockStore) UpsertReading(context.Context, *models.Reading) error { return nil }
-func (s *mockStore) Close() error                                         { return nil }
+func (s *mockStore) CreateReading(_ context.Context, r *models.Reading) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.createReadingErr != nil {
+		return s.createReadingErr
+	}
+	cp := *r
+	s.createdReadings = append(s.createdReadings, cp)
+	return nil
+}
+
+func (s *mockStore) UpsertReading(_ context.Context, r *models.Reading) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.upsertReadingErr != nil {
+		return s.upsertReadingErr
+	}
+	cp := *r
+	s.upsertedReadings = append(s.upsertedReadings, cp)
+	return nil
+}
+
+func (s *mockStore) Close() error { return nil }
 
 // --- Mock notifier ---
 
@@ -494,6 +521,28 @@ func withDocker(d Runner) func(*Orchestrator) {
 
 func withS3(s S3Client) func(*Orchestrator) {
 	return func(o *Orchestrator) { o.s3 = s }
+}
+
+func withEmbedder(e embeddings.Embedder) func(*Orchestrator) {
+	return func(o *Orchestrator) { o.embedder = e }
+}
+
+// mockEmbedder records Embed calls and returns a fixed vector or injected error.
+type mockEmbedder struct {
+	mu      sync.Mutex
+	calls   []string
+	vector  []float32
+	errToFn error
+}
+
+func (m *mockEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, text)
+	if m.errToFn != nil {
+		return nil, m.errToFn
+	}
+	return m.vector, nil
 }
 
 // newLocalInstance creates a standard local instance for tests.

--- a/internal/orchestrator/monitor.go
+++ b/internal/orchestrator/monitor.go
@@ -142,6 +142,20 @@ func (o *Orchestrator) handleCompletion(ctx context.Context, task *models.Task, 
 		result.Error = status.Error
 	}
 
+	// Reading-mode completion: embed TL;DR and write the reading row synchronously.
+	// If embedding or the DB write fails, the task itself fails.
+	var readingOpt notify.EventOption
+	if task.TaskMode == models.TaskModeRead && result.Status == models.TaskStatusCompleted {
+		opt, err := o.handleReadingCompletion(ctx, task, status)
+		if err != nil {
+			log.Error().Err(err).Str("task_id", task.ID).Msg("handleReadingCompletion: reading pipeline failed")
+			result.Status = models.TaskStatusFailed
+			result.Error = err.Error()
+		} else {
+			readingOpt = opt
+		}
+	}
+
 	if err := o.store.CompleteTask(ctx, task.ID, result); err != nil {
 		log.Error().Err(err).Str("task_id", task.ID).Msg("handleCompletion: failed to complete task in store")
 	}
@@ -150,7 +164,11 @@ func (o *Orchestrator) handleCompletion(ctx context.Context, task *models.Task, 
 	// Emit exactly one event per completion.
 	switch {
 	case result.Status == models.TaskStatusCompleted:
-		o.bus.Emit(notify.NewEvent(notify.EventTaskCompleted, task, notify.WithContainerStatus(status.PRURL, "", status.LogTail)))
+		opts := []notify.EventOption{notify.WithContainerStatus(status.PRURL, "", status.LogTail)}
+		if readingOpt != nil {
+			opts = append(opts, readingOpt)
+		}
+		o.bus.Emit(notify.NewEvent(notify.EventTaskCompleted, task, opts...))
 	case status.NeedsInput:
 		o.markRetryReady(ctx, task, notify.EventTaskNeedsInput, notify.WithContainerStatus("", status.Question, status.LogTail))
 	default:
@@ -158,6 +176,78 @@ func (o *Orchestrator) handleCompletion(ctx context.Context, task *models.Task, 
 	}
 
 	log.Info().Str("task_id", task.ID).Str("status", string(result.Status)).Msg("task completed")
+}
+
+// handleReadingCompletion embeds the agent's final TL;DR and writes the reading
+// row. Returns an EventOption that populates the reading fields on the
+// task.completed event. Any error here causes the task itself to fail.
+func (o *Orchestrator) handleReadingCompletion(ctx context.Context, task *models.Task, status ContainerStatus) (notify.EventOption, error) {
+	if o.embedder == nil {
+		return nil, fmt.Errorf("reading completion: no embedder configured")
+	}
+
+	vec, err := o.embedder.Embed(ctx, status.TLDR)
+	if err != nil {
+		return nil, fmt.Errorf("embed tldr: %w", err)
+	}
+
+	raw, err := json.Marshal(agentStatusFromContainer(status))
+	if err != nil {
+		return nil, fmt.Errorf("marshal raw_output: %w", err)
+	}
+
+	reading := &models.Reading{
+		TaskID:         task.ID,
+		URL:            status.URL,
+		Title:          status.Title,
+		TLDR:           status.TLDR,
+		Tags:           status.Tags,
+		Keywords:       status.Keywords,
+		People:         status.People,
+		Orgs:           status.Orgs,
+		NoveltyVerdict: status.NoveltyVerdict,
+		Connections:    status.Connections,
+		Summary:        status.SummaryMarkdown,
+		RawOutput:      raw,
+		Embedding:      vec,
+	}
+
+	if task.Force {
+		if err := o.store.UpsertReading(ctx, reading); err != nil {
+			return nil, fmt.Errorf("upsert reading: %w", err)
+		}
+	} else {
+		if err := o.store.CreateReading(ctx, reading); err != nil {
+			return nil, fmt.Errorf("create reading: %w", err)
+		}
+	}
+
+	return notify.WithReading(status.TLDR, status.NoveltyVerdict, status.Tags, status.Connections), nil
+}
+
+// agentStatusFromContainer reconstructs the reading-relevant portion of the
+// agent's status output from the parsed ContainerStatus. Used to populate the
+// reading's raw_output JSONB losslessly without depending on the original bytes.
+func agentStatusFromContainer(s ContainerStatus) AgentStatus {
+	return AgentStatus{
+		Complete:        s.Complete,
+		PRURL:           s.PRURL,
+		CostUSD:         s.CostUSD,
+		ElapsedTimeSec:  s.ElapsedTimeSec,
+		RepoURL:         s.RepoURL,
+		TargetBranch:    s.TargetBranch,
+		TaskMode:        s.TaskMode,
+		URL:             s.URL,
+		Title:           s.Title,
+		TLDR:            s.TLDR,
+		Tags:            s.Tags,
+		Keywords:        s.Keywords,
+		People:          s.People,
+		Orgs:            s.Orgs,
+		NoveltyVerdict:  s.NoveltyVerdict,
+		Connections:     s.Connections,
+		SummaryMarkdown: s.SummaryMarkdown,
+	}
 }
 
 // saveAgentOutput extracts the agent's output log from the container and uploads

--- a/internal/orchestrator/monitor.go
+++ b/internal/orchestrator/monitor.go
@@ -186,6 +186,9 @@ func (o *Orchestrator) handleReadingCompletion(ctx context.Context, task *models
 	if o.embedder == nil {
 		return nil, fmt.Errorf("reading completion: no embedder configured")
 	}
+	if status.URL == "" {
+		return nil, fmt.Errorf("reading completion: agent reported empty url")
+	}
 
 	vec, err := o.embedder.Embed(ctx, status.TLDR)
 	if err != nil {

--- a/internal/orchestrator/monitor.go
+++ b/internal/orchestrator/monitor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/oklog/ulid/v2"
 	"github.com/rs/zerolog/log"
 
 	"github.com/backflow-labs/backflow/internal/config"
@@ -197,6 +198,7 @@ func (o *Orchestrator) handleReadingCompletion(ctx context.Context, task *models
 	}
 
 	reading := &models.Reading{
+		ID:             "bf_" + ulid.Make().String(),
 		TaskID:         task.ID,
 		URL:            status.URL,
 		Title:          status.Title,
@@ -210,6 +212,7 @@ func (o *Orchestrator) handleReadingCompletion(ctx context.Context, task *models
 		Summary:        status.SummaryMarkdown,
 		RawOutput:      raw,
 		Embedding:      vec,
+		CreatedAt:      time.Now().UTC(),
 	}
 
 	if task.Force {

--- a/internal/orchestrator/monitor_test.go
+++ b/internal/orchestrator/monitor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -521,6 +522,12 @@ func TestHandleCompletion_ReadSuccess_EmbedsAndCreatesReading(t *testing.T) {
 	if len(r.RawOutput) == 0 {
 		t.Errorf("reading.RawOutput should be populated")
 	}
+	if !strings.HasPrefix(r.ID, "bf_") {
+		t.Errorf("reading.ID = %q, want bf_-prefixed ULID", r.ID)
+	}
+	if r.CreatedAt.IsZero() {
+		t.Errorf("reading.CreatedAt is zero, want non-zero")
+	}
 
 	// Emitted event should be task.completed with reading fields set.
 	events := n.eventTypes()
@@ -541,6 +548,55 @@ func TestHandleCompletion_ReadSuccess_EmbedsAndCreatesReading(t *testing.T) {
 	}
 	if len(e.Connections) != 1 {
 		t.Errorf("event.Connections = %+v", e.Connections)
+	}
+}
+
+func TestHandleCompletion_ReadSuccess_AssignsUniqueReadingIDs(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+
+	s.CreateInstance(context.Background(), newLocalInstance())
+
+	for i, url := range []string{"https://example.com/a", "https://example.com/b"} {
+		id := fmt.Sprintf("bf_read_%d", i)
+		s.CreateTask(context.Background(), &models.Task{
+			ID:          id,
+			Status:      models.TaskStatusRunning,
+			TaskMode:    models.TaskModeRead,
+			Prompt:      url,
+			InstanceID:  "local",
+			ContainerID: "cont1",
+			StartedAt:   &now,
+		})
+
+		bus, _ := newTestBus()
+		emb := &mockEmbedder{vector: []float32{0.1}}
+		o := newTestOrchestrator(s, bus, withEmbedder(emb))
+		o.running = 1
+
+		task, _ := s.GetTask(context.Background(), id)
+		o.handleCompletion(context.Background(), task, ContainerStatus{
+			Done:     true,
+			Complete: true,
+			TaskMode: models.TaskModeRead,
+			URL:      url,
+			TLDR:     "summary " + url,
+		})
+		bus.Close()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.createdReadings) != 2 {
+		t.Fatalf("createdReadings = %d, want 2", len(s.createdReadings))
+	}
+	if s.createdReadings[0].ID == s.createdReadings[1].ID {
+		t.Errorf("reading IDs collided: %q == %q", s.createdReadings[0].ID, s.createdReadings[1].ID)
+	}
+	for i, r := range s.createdReadings {
+		if !strings.HasPrefix(r.ID, "bf_") {
+			t.Errorf("reading[%d].ID = %q, want bf_-prefixed", i, r.ID)
+		}
 	}
 }
 

--- a/internal/orchestrator/monitor_test.go
+++ b/internal/orchestrator/monitor_test.go
@@ -600,6 +600,65 @@ func TestHandleCompletion_ReadSuccess_AssignsUniqueReadingIDs(t *testing.T) {
 	}
 }
 
+func TestHandleCompletion_ReadEmptyURL_MarksTaskFailed(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+
+	s.CreateInstance(context.Background(), newLocalInstance())
+
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_read_empty_url",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeRead,
+		Prompt:      "https://example.com/post",
+		InstanceID:  "local",
+		ContainerID: "cont1",
+		StartedAt:   &now,
+	})
+
+	bus, n := newTestBus()
+	emb := &mockEmbedder{vector: []float32{0.1}}
+	o := newTestOrchestrator(s, bus, withEmbedder(emb))
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_read_empty_url")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:     true,
+		Complete: true,
+		TaskMode: models.TaskModeRead,
+		URL:      "",
+		TLDR:     "short summary",
+	})
+	bus.Close()
+
+	got, _ := s.GetTask(context.Background(), "bf_read_empty_url")
+	if got.Status != models.TaskStatusFailed {
+		t.Errorf("task.Status = %q, want failed", got.Status)
+	}
+	if !strings.Contains(got.Error, "url") {
+		t.Errorf("task.Error = %q, want something about url", got.Error)
+	}
+
+	s.mu.Lock()
+	if len(s.createdReadings) != 0 || len(s.upsertedReadings) != 0 {
+		t.Errorf("no reading should be written for empty URL: created=%d upserted=%d",
+			len(s.createdReadings), len(s.upsertedReadings))
+	}
+	s.mu.Unlock()
+
+	// Embedder should not be called when URL is missing.
+	emb.mu.Lock()
+	if len(emb.calls) != 0 {
+		t.Errorf("embedder calls = %v, want none for empty URL", emb.calls)
+	}
+	emb.mu.Unlock()
+
+	events := n.eventTypes()
+	if len(events) != 1 || events[0] != notify.EventTaskFailed {
+		t.Errorf("events = %v, want [task.failed]", events)
+	}
+}
+
 func TestHandleCompletion_ReadStoreFailure_MarksTaskFailed(t *testing.T) {
 	s := newMockStore()
 	s.createReadingErr = fmt.Errorf("db write failed")

--- a/internal/orchestrator/monitor_test.go
+++ b/internal/orchestrator/monitor_test.go
@@ -431,6 +431,258 @@ func TestHandleCompletion_PropagatesInferredFields(t *testing.T) {
 	}
 }
 
+func TestHandleCompletion_ReadSuccess_EmbedsAndCreatesReading(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+
+	s.CreateInstance(context.Background(), newLocalInstance())
+
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_read_ok",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeRead,
+		Prompt:      "https://example.com/post",
+		InstanceID:  "local",
+		ContainerID: "cont1",
+		StartedAt:   &now,
+	})
+
+	bus, n := newTestBus()
+	emb := &mockEmbedder{vector: []float32{0.1, 0.2, 0.3}}
+	o := newTestOrchestrator(s, bus, withEmbedder(emb))
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_read_ok")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:            true,
+		Complete:        true,
+		TaskMode:        models.TaskModeRead,
+		URL:             "https://example.com/post",
+		Title:           "Post title",
+		TLDR:            "short summary",
+		Tags:            []string{"ai", "systems"},
+		Keywords:        []string{"retrieval"},
+		People:          []string{"Ada"},
+		Orgs:            []string{"Example Corp"},
+		NoveltyVerdict:  "new",
+		Connections:     []models.Connection{{ReadingID: "bf_other", Reason: "same topic"}},
+		SummaryMarkdown: "# Long summary",
+	})
+	bus.Close()
+
+	// Task should be completed.
+	got, _ := s.GetTask(context.Background(), "bf_read_ok")
+	if got.Status != models.TaskStatusCompleted {
+		t.Errorf("task.Status = %q, want completed", got.Status)
+	}
+
+	// Embedder was called with the TL;DR.
+	emb.mu.Lock()
+	if len(emb.calls) != 1 || emb.calls[0] != "short summary" {
+		t.Errorf("embedder calls = %v, want [short summary]", emb.calls)
+	}
+	emb.mu.Unlock()
+
+	// CreateReading received the reading, UpsertReading was NOT called.
+	s.mu.Lock()
+	if len(s.createdReadings) != 1 {
+		t.Fatalf("createdReadings = %d, want 1", len(s.createdReadings))
+	}
+	if len(s.upsertedReadings) != 0 {
+		t.Errorf("upsertedReadings = %d, want 0 for non-force task", len(s.upsertedReadings))
+	}
+	r := s.createdReadings[0]
+	s.mu.Unlock()
+
+	if r.URL != "https://example.com/post" {
+		t.Errorf("reading.URL = %q", r.URL)
+	}
+	if r.Title != "Post title" {
+		t.Errorf("reading.Title = %q", r.Title)
+	}
+	if r.TLDR != "short summary" {
+		t.Errorf("reading.TLDR = %q", r.TLDR)
+	}
+	if r.NoveltyVerdict != "new" {
+		t.Errorf("reading.NoveltyVerdict = %q", r.NoveltyVerdict)
+	}
+	if r.TaskID != "bf_read_ok" {
+		t.Errorf("reading.TaskID = %q", r.TaskID)
+	}
+	if len(r.Embedding) != 3 || r.Embedding[0] != 0.1 {
+		t.Errorf("reading.Embedding = %v, want [0.1 0.2 0.3]", r.Embedding)
+	}
+	if len(r.Tags) != 2 {
+		t.Errorf("reading.Tags = %v", r.Tags)
+	}
+	if len(r.Connections) != 1 || r.Connections[0].ReadingID != "bf_other" {
+		t.Errorf("reading.Connections = %+v", r.Connections)
+	}
+	if len(r.RawOutput) == 0 {
+		t.Errorf("reading.RawOutput should be populated")
+	}
+
+	// Emitted event should be task.completed with reading fields set.
+	events := n.eventTypes()
+	if len(events) != 1 || events[0] != notify.EventTaskCompleted {
+		t.Fatalf("events = %v, want [task.completed]", events)
+	}
+	n.mu.Lock()
+	e := n.events[0]
+	n.mu.Unlock()
+	if e.TLDR != "short summary" {
+		t.Errorf("event.TLDR = %q", e.TLDR)
+	}
+	if e.NoveltyVerdict != "new" {
+		t.Errorf("event.NoveltyVerdict = %q", e.NoveltyVerdict)
+	}
+	if len(e.Tags) != 2 {
+		t.Errorf("event.Tags = %v", e.Tags)
+	}
+	if len(e.Connections) != 1 {
+		t.Errorf("event.Connections = %+v", e.Connections)
+	}
+}
+
+func TestHandleCompletion_ReadStoreFailure_MarksTaskFailed(t *testing.T) {
+	s := newMockStore()
+	s.createReadingErr = fmt.Errorf("db write failed")
+	now := time.Now().UTC()
+
+	s.CreateInstance(context.Background(), newLocalInstance())
+
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_read_store_fail",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeRead,
+		Prompt:      "https://example.com/post",
+		InstanceID:  "local",
+		ContainerID: "cont1",
+		StartedAt:   &now,
+	})
+
+	bus, n := newTestBus()
+	emb := &mockEmbedder{vector: []float32{0.1}}
+	o := newTestOrchestrator(s, bus, withEmbedder(emb))
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_read_store_fail")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:     true,
+		Complete: true,
+		TaskMode: models.TaskModeRead,
+		URL:      "https://example.com/post",
+		TLDR:     "short summary",
+	})
+	bus.Close()
+
+	got, _ := s.GetTask(context.Background(), "bf_read_store_fail")
+	if got.Status != models.TaskStatusFailed {
+		t.Errorf("task.Status = %q, want failed", got.Status)
+	}
+
+	events := n.eventTypes()
+	if len(events) != 1 || events[0] != notify.EventTaskFailed {
+		t.Errorf("events = %v, want [task.failed]", events)
+	}
+}
+
+func TestHandleCompletion_ReadEmbedFailure_MarksTaskFailed(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+
+	s.CreateInstance(context.Background(), newLocalInstance())
+
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_read_embed_fail",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeRead,
+		Prompt:      "https://example.com/post",
+		InstanceID:  "local",
+		ContainerID: "cont1",
+		StartedAt:   &now,
+	})
+
+	bus, n := newTestBus()
+	emb := &mockEmbedder{errToFn: fmt.Errorf("openai down")}
+	o := newTestOrchestrator(s, bus, withEmbedder(emb))
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_read_embed_fail")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:     true,
+		Complete: true,
+		TaskMode: models.TaskModeRead,
+		URL:      "https://example.com/post",
+		TLDR:     "short summary",
+	})
+	bus.Close()
+
+	got, _ := s.GetTask(context.Background(), "bf_read_embed_fail")
+	if got.Status != models.TaskStatusFailed {
+		t.Errorf("task.Status = %q, want failed", got.Status)
+	}
+	if got.Error == "" {
+		t.Error("expected non-empty task.Error when embedding fails")
+	}
+
+	s.mu.Lock()
+	if len(s.createdReadings) != 0 || len(s.upsertedReadings) != 0 {
+		t.Errorf("reading written on embed failure: created=%d upserted=%d", len(s.createdReadings), len(s.upsertedReadings))
+	}
+	s.mu.Unlock()
+
+	events := n.eventTypes()
+	if len(events) != 1 || events[0] != notify.EventTaskFailed {
+		t.Errorf("events = %v, want [task.failed]", events)
+	}
+}
+
+func TestHandleCompletion_ReadForce_CallsUpsertReading(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+
+	s.CreateInstance(context.Background(), newLocalInstance())
+
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_read_force",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeRead,
+		Force:       true,
+		Prompt:      "https://example.com/post",
+		InstanceID:  "local",
+		ContainerID: "cont1",
+		StartedAt:   &now,
+	})
+
+	bus, _ := newTestBus()
+	emb := &mockEmbedder{vector: []float32{0.9}}
+	o := newTestOrchestrator(s, bus, withEmbedder(emb))
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_read_force")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:     true,
+		Complete: true,
+		TaskMode: models.TaskModeRead,
+		URL:      "https://example.com/post",
+		TLDR:     "updated summary",
+	})
+	bus.Close()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.createdReadings) != 0 {
+		t.Errorf("createdReadings = %d, want 0 for force task", len(s.createdReadings))
+	}
+	if len(s.upsertedReadings) != 1 {
+		t.Fatalf("upsertedReadings = %d, want 1", len(s.upsertedReadings))
+	}
+	if s.upsertedReadings[0].URL != "https://example.com/post" {
+		t.Errorf("upserted URL = %q", s.upsertedReadings[0].URL)
+	}
+}
+
 func TestKillTask(t *testing.T) {
 	s := newMockStore()
 	now := time.Now().UTC()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/backflow-labs/backflow/internal/config"
+	"github.com/backflow-labs/backflow/internal/embeddings"
 	"github.com/backflow-labs/backflow/internal/models"
 	"github.com/backflow-labs/backflow/internal/notify"
 	"github.com/backflow-labs/backflow/internal/store"
@@ -21,13 +22,14 @@ const maxInspectFailures = 3
 // Orchestrator manages the lifecycle of tasks: dispatching them to instances,
 // monitoring their containers, handling completions, and recovering from restarts.
 type Orchestrator struct {
-	store  store.Store
-	config *config.Config
-	bus    *notify.EventBus
-	docker Runner
-	scaler Scaler
-	spot   SpotChecker
-	s3     S3Client
+	store    store.Store
+	config   *config.Config
+	bus      *notify.EventBus
+	docker   Runner
+	scaler   Scaler
+	spot     SpotChecker
+	s3       S3Client
+	embedder embeddings.Embedder
 
 	mu              sync.Mutex
 	running         int
@@ -35,7 +37,7 @@ type Orchestrator struct {
 	inspectFailures map[string]int // task ID -> consecutive inspect failure count
 }
 
-func New(s store.Store, cfg *config.Config, bus *notify.EventBus, runner Runner, scaler Scaler, spot SpotChecker, s3 S3Client) *Orchestrator {
+func New(s store.Store, cfg *config.Config, bus *notify.EventBus, runner Runner, scaler Scaler, spot SpotChecker, s3 S3Client, embedder embeddings.Embedder) *Orchestrator {
 	o := &Orchestrator{
 		store:           s,
 		config:          cfg,
@@ -44,6 +46,7 @@ func New(s store.Store, cfg *config.Config, bus *notify.EventBus, runner Runner,
 		scaler:          scaler,
 		spot:            spot,
 		s3:              s3,
+		embedder:        embedder,
 		stopCh:          make(chan struct{}),
 		inspectFailures: make(map[string]int),
 	}

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -34,6 +34,18 @@ type ContainerStatus struct {
 	RepoURL        string
 	TargetBranch   string
 	TaskMode       string
+
+	// Reading-mode fields (populated only for TaskModeRead).
+	URL             string
+	Title           string
+	TLDR            string
+	Tags            []string
+	Keywords        []string
+	People          []string
+	Orgs            []string
+	NoveltyVerdict  string
+	Connections     []models.Connection
+	SummaryMarkdown string
 }
 
 // AgentStatus is the JSON structure written by the agent entrypoint to
@@ -49,6 +61,18 @@ type AgentStatus struct {
 	RepoURL        string  `json:"repo_url,omitempty"`
 	TargetBranch   string  `json:"target_branch,omitempty"`
 	TaskMode       string  `json:"task_mode,omitempty"`
+
+	// Reading-mode fields (populated only for TaskModeRead).
+	URL             string              `json:"url,omitempty"`
+	Title           string              `json:"title,omitempty"`
+	TLDR            string              `json:"tldr,omitempty"`
+	Tags            []string            `json:"tags,omitempty"`
+	Keywords        []string            `json:"keywords,omitempty"`
+	People          []string            `json:"people,omitempty"`
+	Orgs            []string            `json:"orgs,omitempty"`
+	NoveltyVerdict  string              `json:"novelty_verdict,omitempty"`
+	Connections     []models.Connection `json:"connections,omitempty"`
+	SummaryMarkdown string              `json:"summary_markdown,omitempty"`
 }
 
 // SpotChecker detects spot/preemption interruptions and re-queues affected tasks.

--- a/internal/orchestrator/runner_test.go
+++ b/internal/orchestrator/runner_test.go
@@ -1,0 +1,72 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAgentStatus_ParsesReadingFields(t *testing.T) {
+	raw := []byte(`{
+		"complete": true,
+		"url": "https://example.com/post",
+		"title": "Post title",
+		"tldr": "Short summary",
+		"tags": ["ai", "systems"],
+		"keywords": ["embeddings", "retrieval"],
+		"people": ["Ada"],
+		"orgs": ["Example Corp"],
+		"novelty_verdict": "new",
+		"connections": [
+			{"reading_id": "bf_other", "reason": "same topic"}
+		],
+		"summary_markdown": "# Long summary"
+	}`)
+
+	var got AgentStatus
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.URL != "https://example.com/post" {
+		t.Errorf("URL = %q", got.URL)
+	}
+	if got.Title != "Post title" {
+		t.Errorf("Title = %q", got.Title)
+	}
+	if got.TLDR != "Short summary" {
+		t.Errorf("TLDR = %q", got.TLDR)
+	}
+	if got.NoveltyVerdict != "new" {
+		t.Errorf("NoveltyVerdict = %q", got.NoveltyVerdict)
+	}
+	if got.SummaryMarkdown != "# Long summary" {
+		t.Errorf("SummaryMarkdown = %q", got.SummaryMarkdown)
+	}
+	if want := []string{"ai", "systems"}; !equalStrings(got.Tags, want) {
+		t.Errorf("Tags = %v, want %v", got.Tags, want)
+	}
+	if want := []string{"embeddings", "retrieval"}; !equalStrings(got.Keywords, want) {
+		t.Errorf("Keywords = %v, want %v", got.Keywords, want)
+	}
+	if want := []string{"Ada"}; !equalStrings(got.People, want) {
+		t.Errorf("People = %v, want %v", got.People, want)
+	}
+	if want := []string{"Example Corp"}; !equalStrings(got.Orgs, want) {
+		t.Errorf("Orgs = %v, want %v", got.Orgs, want)
+	}
+	if len(got.Connections) != 1 || got.Connections[0].ReadingID != "bf_other" || got.Connections[0].Reason != "same topic" {
+		t.Errorf("Connections = %+v", got.Connections)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -74,7 +74,7 @@ const taskColumns = `id, status, task_mode, harness, repo_url, branch, target_br
 	create_pr, self_review, save_agent_output, pr_title, pr_body, pr_url, output_url,
 	allowed_tools, claude_md, env_vars,
 	instance_id, container_id, retry_count, user_retry_count, cost_usd, elapsed_time_sec, error,
-	ready_for_retry, reply_channel, agent_image,
+	ready_for_retry, reply_channel, agent_image, force,
 	created_at, updated_at, started_at, completed_at`
 
 func (s *PostgresStore) CreateTask(ctx context.Context, task *models.Task) error {
@@ -95,7 +95,7 @@ func (s *PostgresStore) CreateTask(ctx context.Context, task *models.Task) error
 			create_pr, self_review, save_agent_output, pr_title, pr_body, pr_url, output_url,
 			allowed_tools, claude_md, env_vars,
 			instance_id, container_id, retry_count, user_retry_count, cost_usd, elapsed_time_sec, error,
-			ready_for_retry, reply_channel, agent_image,
+			ready_for_retry, reply_channel, agent_image, force,
 			created_at, updated_at, started_at, completed_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7,
@@ -104,8 +104,8 @@ func (s *PostgresStore) CreateTask(ctx context.Context, task *models.Task) error
 			$15, $16, $17, $18, $19, $20, $21,
 			$22, $23, $24,
 			$25, $26, $27, $28, $29, $30, $31,
-			$32, $33, $34,
-			$35, $36, $37, $38
+			$32, $33, $34, $35,
+			$36, $37, $38, $39
 		)`,
 		task.ID, task.Status, task.TaskMode, task.Harness, task.RepoURL, task.Branch, task.TargetBranch,
 		task.Prompt, task.Context, task.Model, task.Effort,
@@ -114,7 +114,7 @@ func (s *PostgresStore) CreateTask(ctx context.Context, task *models.Task) error
 		task.PRTitle, task.PRBody, task.PRURL, task.OutputURL,
 		allowedTools, task.ClaudeMD, envVars,
 		task.InstanceID, task.ContainerID, task.RetryCount, task.UserRetryCount, task.CostUSD, task.ElapsedTimeSec, task.Error,
-		task.ReadyForRetry, task.ReplyChannel, task.AgentImage,
+		task.ReadyForRetry, task.ReplyChannel, task.AgentImage, task.Force,
 		task.CreatedAt, task.UpdatedAt, task.StartedAt, task.CompletedAt,
 	)
 	return err
@@ -550,7 +550,7 @@ func scanPGTask(row pgScanner) (*models.Task, error) {
 		&t.PRTitle, &t.PRBody, &t.PRURL, &t.OutputURL,
 		&allowedTools, &t.ClaudeMD, &envVars,
 		&t.InstanceID, &t.ContainerID, &t.RetryCount, &t.UserRetryCount, &t.CostUSD, &t.ElapsedTimeSec, &t.Error,
-		&t.ReadyForRetry, &t.ReplyChannel, &t.AgentImage,
+		&t.ReadyForRetry, &t.ReplyChannel, &t.AgentImage, &t.Force,
 		&t.CreatedAt, &t.UpdatedAt, &t.StartedAt, &t.CompletedAt,
 	)
 	if err != nil {

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -230,6 +230,37 @@ func TestPG_TaskRoundTrip_DefaultAgentImage(t *testing.T) {
 	if got.AgentImage != "" {
 		t.Errorf("AgentImage = %q, want empty (default)", got.AgentImage)
 	}
+	if got.Force {
+		t.Errorf("Force = true, want false (default)")
+	}
+}
+
+func TestPG_CreateTask_PersistsForce(t *testing.T) {
+	s := testPostgresStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	task := &models.Task{
+		ID:        "bf_TEST_FORCE",
+		Status:    models.TaskStatusPending,
+		TaskMode:  models.TaskModeRead,
+		Harness:   models.HarnessClaudeCode,
+		Prompt:    "https://example.com/post",
+		Force:     true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	got, err := s.GetTask(ctx, "bf_TEST_FORCE")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if !got.Force {
+		t.Errorf("Force = false, want true")
+	}
 }
 
 func TestPG_APIKeyRoundTrip(t *testing.T) {

--- a/migrations/012_task_force.sql
+++ b/migrations/012_task_force.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE tasks ADD COLUMN force BOOLEAN NOT NULL DEFAULT false;
+
+-- +goose Down
+
+ALTER TABLE tasks DROP COLUMN IF EXISTS force;

--- a/test/blackbox/fake-agent/fake_agent_test.go
+++ b/test/blackbox/fake-agent/fake_agent_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -221,7 +222,7 @@ func TestFakeAgent(t *testing.T) {
 				if err := json.Unmarshal(logPayload, &logStatus); err != nil {
 					t.Fatalf("BACKFLOW_STATUS_JSON line failed to parse: %v\nraw: %s", err, logPayload)
 				}
-				if logStatus != agentStatus {
+				if !reflect.DeepEqual(logStatus, agentStatus) {
 					t.Errorf("BACKFLOW_STATUS_JSON status != status.json\nlog:  %+v\nfile: %+v", logStatus, agentStatus)
 				}
 			} else {


### PR DESCRIPTION
## Summary

Implements the orchestrator-side completion pipeline for reading-mode tasks (issue #174): parse the reader agent's structured output, embed the final TL;DR, write the `readings` row (insert or upsert on force), and enrich the `task.completed` event so downstream notifiers (#177) can format reading-specific output.

Blocked-by issues (#171 readings store, #172 reader image, #173 agent_image + config) already merged. This PR fills in the remaining "container exits → row in `readings`" glue. Behavior is synchronous: if the embedding API call or DB write fails, the task is marked `failed` rather than silently `completed`.

## What's in this PR

### New `internal/embeddings/` package

- `Embedder` interface: `Embed(ctx, text) ([]float32, error)`.
- `OpenAIEmbedder`: thin HTTP client, no SDK. POSTs to `https://api.openai.com/v1/embeddings` with `text-embedding-3-small`. Single-shot (no retries) — failures surface as task failures.
- Unit tests use `httptest.NewServer` to stub OpenAI: request shape, auth header, response parsing, non-200 error, empty data.

### Status JSON extensions

- `AgentStatus` gains `URL`, `Title`, `TLDR`, `Tags`, `Keywords`, `People`, `Orgs`, `NoveltyVerdict`, `Connections []models.Connection`, `SummaryMarkdown`.
- `ContainerStatus` mirrors those fields.
- `docker.enrichFromStatusJSON` (EC2/local) and `fargate.parseStatusFromLogEvents` both pass the new fields through.
- `fake_agent_test.go` switched from `!=` to `reflect.DeepEqual` now that `AgentStatus` contains slices.

### `Task.Force` field

- `Force bool` on `models.Task`, persisted via new migration `012_task_force.sql` (`force BOOLEAN NOT NULL DEFAULT false`).
- `postgres.go` scan / insert / column list updated.
- Integration test `TestPG_CreateTask_PersistsForce` round-trips against a real pgvector Postgres via testcontainers.
- Decided to add Force here rather than defer to #175 so the UpsertReading branch in the completion handler has a real signal to check; #175 remains pure API wiring. See `HANDOFF.md`.

### `Event` struct extensions

- New fields: `TaskMode`, `TLDR`, `NoveltyVerdict`, `Tags`, `Connections []models.Connection`, all `omitempty`.
- `NewEvent` now copies `task.TaskMode` onto the event — one line that unblocks #177 (the Discord reading embed formatter) without further plumbing.
- New `WithReading(tldr, verdict, tags, connections)` `EventOption`.

### `handleReadingCompletion` in `monitor.go`

- Branches on `task.TaskMode == TaskModeRead && result.Status == completed`, invoked **before** `store.CompleteTask` so failures cleanly flip the task to `failed`.
- Embeds `status.TLDR`, marshals the parsed `AgentStatus` as `RawOutput`, and calls `store.UpsertReading` when `task.Force` is true, otherwise `store.CreateReading`.
- Returns a `notify.WithReading` option that the success-path event emitter appends to `WithContainerStatus`.
- Any failure (nil embedder, embed error, DB error) sets `result.Status = failed`, `result.Error = err.Error()` before `CompleteTask` runs.

### Orchestrator wiring

- `Orchestrator` struct gains `embedder embeddings.Embedder`; constructor signature extended.
- `cmd/backflow/main.go` constructs a concrete `OpenAIEmbedder` from `cfg.OpenAIAPIKey` when set, otherwise passes `nil` (reading tasks then fail at completion with a clear error).

### Test coverage

Unit tests in `internal/orchestrator/monitor_test.go` use a mocked store (embeds `store.Store`) and a mocked embedder:

- `TestHandleCompletion_ReadSuccess_EmbedsAndCreatesReading` — parse → embed → insert → emit `task.completed` with reading fields populated.
- `TestHandleCompletion_ReadForce_CallsUpsertReading` — `task.Force=true` path calls `UpsertReading`, not `CreateReading`.
- `TestHandleCompletion_ReadEmbedFailure_MarksTaskFailed` — embed error flips task to `failed`, no reading written, `task.failed` emitted.
- `TestHandleCompletion_ReadStoreFailure_MarksTaskFailed` — `CreateReading` error flips task to `failed`, `task.failed` emitted.

Plus `runner_test.go` for `AgentStatus` JSON round-trip, `embeddings/embeddings_test.go` for the HTTP client, and `postgres_test.go` for the Force column.

### Documentation

- `CLAUDE.md` — new **Reading mode** section describing the completion pipeline and env vars; module descriptions updated to mention `internal/embeddings`, `handleReadingCompletion`, new `Event` fields, `CreateReading`/`UpsertReading`. New **HANDOFF.md** section describing when to read and write the handoff ledger.
- `README.md` — reading mode mentioned in intro; `read` added to `task_mode` description; new **Reading Mode** env-var table.
- `docs/schema.md` — `tasks` table: `agent_image` and `force` columns (both were missing); new `readings` table section with columns, indexes, RLS, and pointers to `supabase-setup.md`.
- `HANDOFF.md` — new ledger capturing decisions made here (Force-now vs defer, TaskMode-on-event-now vs defer, single-shot embedder, `raw_output` as marshaled `AgentStatus`) and consequences for #175 and #177.

## Decisions captured

The three decisions the user approved explicitly, for the record:

1. **Add `Force` in #174** — rather than deferring to #175. Makes the completion handler testable and keeps #175 as pure API wiring.
2. **Populate `Event.TaskMode` in `NewEvent`** — rather than deferring to #177. One-line change, unblocks Discord formatting.
3. **Single-shot embeddings client** — no retries. Failures surface as task failures; higher-level retry already exists.

Full reasoning in `HANDOFF.md`.

## Test plan

- [x] `make lint` passes.
- [x] `make test` passes, including new unit tests.
- [x] `internal/store/` testcontainers integration passes: migration 012 applies and rolls back cleanly, `Force` round-trips.
- [x] `go build ./...` clean.
- [ ] Post-merge: submit a real reader task and verify the `readings` row plus `task.completed` webhook payload include the TL;DR and connections.

## Pre-existing flake

`TestFakeAgentTimeout` in `test/blackbox/fake-agent/` fails on `main` as well — unrelated to this work; left alone.