### PR TITLE
Append "Reply STOP to unsubscribe" footer to outbound SMS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,9 @@ make test-schema        # Schemathesis fuzz tests against OpenAPI spec (requires
 make test-blackbox      # Black-box integration test (builds fake agent, spins up server + DB)
 make test-soak          # Soak test (10 min short mode; warns before truncating tasks DB)
 make test-fake-agent    # Unit tests for the fake agent Docker image
+make test-reader-scripts         # Reader-agent shell script tests
+make test-reader-status-writer   # Reader-agent status writer test
+make test-docker-status-writer   # Agent-container status writer test
 make docker-fake-agent-build  # Build fake agent image for testing
 make deps               # go mod tidy
 make clean              # Remove bin/ directory
@@ -28,9 +31,13 @@ make docker-agent-deploy      # Full agent ECR pipeline: login, buildx, push
 make docker-server-build       # Buildx multi-platform server image (amd64+arm64)
 make docker-server-build-local # Single-architecture server build
 make docker-server-deploy      # Full server ECR pipeline: login, buildx, push
+make docker-reader-build       # Buildx multi-platform reader image (amd64+arm64)
+make docker-reader-build-local # Single-architecture reader build
+make docker-reader-push        # Tag + push reader to ECR (requires REGISTRY=<ecr-uri>)
+make docker-reader-deploy      # Full reader ECR pipeline: login, buildx, push
 make setup-aws          # Create AWS infrastructure
-make copy-env           # Copy .env from ~/dev/etc/.env to local .env
-make overwrite-env      # Copy local .env to ~/dev/etc/.env
+make restore-env        # Copy ~/dev/etc/backflow/.env → ./.env
+make backup-env         # Copy ./.env → ~/dev/etc/backflow/.env
 goose -dir migrations status # Show pending/applied migrations
 goose -dir migrations up     # Apply the next migration(s)
 goose -dir migrations down   # Roll back the last migration

--- a/internal/messaging/inbound.go
+++ b/internal/messaging/inbound.go
@@ -35,7 +35,7 @@ type twiMLMessage struct {
 func writeTwiML(w http.ResponseWriter, msg string) {
 	resp := twiMLResponse{}
 	if msg != "" {
-		resp.Message = &twiMLMessage{Body: msg}
+		resp.Message = &twiMLMessage{Body: msg + "\n" + UnsubscribeFooter}
 	}
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(http.StatusOK)

--- a/internal/messaging/inbound_test.go
+++ b/internal/messaging/inbound_test.go
@@ -193,6 +193,9 @@ func TestInboundHandler_AllowedSender(t *testing.T) {
 	if strings.Contains(resp.Message.Body, "Repo:") {
 		t.Errorf("response should not contain Repo line: %q", resp.Message.Body)
 	}
+	if !strings.HasSuffix(resp.Message.Body, "\n"+UnsubscribeFooter) {
+		t.Errorf("response missing unsubscribe footer on its own line: %q", resp.Message.Body)
+	}
 }
 
 func TestInboundHandler_RejectedSender(t *testing.T) {
@@ -217,6 +220,9 @@ func TestInboundHandler_RejectedSender(t *testing.T) {
 	xml.Unmarshal(w.Body.Bytes(), &resp)
 	if resp.Message == nil || !strings.Contains(resp.Message.Body, "not authorized") {
 		t.Errorf("expected rejection message, got %v", resp.Message)
+	}
+	if resp.Message != nil && !strings.HasSuffix(resp.Message.Body, "\n"+UnsubscribeFooter) {
+		t.Errorf("rejection response missing unsubscribe footer: %q", resp.Message.Body)
 	}
 }
 

--- a/internal/messaging/messenger.go
+++ b/internal/messaging/messenger.go
@@ -9,6 +9,10 @@ const (
 	ChannelSMS ChannelType = "sms"
 )
 
+// UnsubscribeFooter is appended on a new line to every outbound SMS — both
+// REST-API sends and TwiML auto-replies — to satisfy 10DLC/TCPA compliance.
+const UnsubscribeFooter = "Reply STOP to unsubscribe"
+
 // Channel identifies a specific endpoint on a transport.
 type Channel struct {
 	Type    ChannelType `json:"type"`

--- a/internal/messaging/twilio.go
+++ b/internal/messaging/twilio.go
@@ -17,6 +17,7 @@ type TwilioMessenger struct {
 	accountSID string
 	authToken  string
 	fromNumber string
+	baseURL    string // overridable in tests; defaults to the Twilio API host
 	httpClient *http.Client
 }
 
@@ -25,17 +26,24 @@ func NewTwilioMessenger(accountSID, authToken, fromNumber string) *TwilioMesseng
 		accountSID: accountSID,
 		authToken:  authToken,
 		fromNumber: fromNumber,
+		baseURL:    "https://api.twilio.com",
 		httpClient: &http.Client{Timeout: 10 * time.Second},
 	}
 }
 
 func (t *TwilioMessenger) Send(ctx context.Context, msg OutboundMessage) error {
-	apiURL := fmt.Sprintf("https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json", t.accountSID)
+	apiURL := fmt.Sprintf("%s/2010-04-01/Accounts/%s/Messages.json", t.baseURL, t.accountSID)
+
+	body := msg.Body
+	if body != "" {
+		body += "\n"
+	}
+	body += UnsubscribeFooter
 
 	form := url.Values{}
 	form.Set("To", msg.Channel.Address)
 	form.Set("From", t.fromNumber)
-	form.Set("Body", msg.Body)
+	form.Set("Body", body)
 
 	var lastErr error
 	for attempt := 0; attempt < 3; attempt++ {

--- a/internal/messaging/twilio_test.go
+++ b/internal/messaging/twilio_test.go
@@ -1,0 +1,42 @@
+package messaging
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTwilioMessenger_AppendsUnsubscribeFooter(t *testing.T) {
+	var gotBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("ParseForm: %v", err)
+		}
+		gotBody = r.PostFormValue("Body")
+		w.WriteHeader(http.StatusCreated)
+		io.WriteString(w, `{"sid":"SMxxx"}`)
+	}))
+	defer ts.Close()
+
+	m := NewTwilioMessenger("ACxxx", "token", "+15550000000")
+	m.baseURL = ts.URL
+
+	err := m.Send(context.Background(), OutboundMessage{
+		Channel: Channel{Type: ChannelSMS, Address: "+15551234567"},
+		Body:    "Task bf_123 completed.",
+	})
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+
+	wantSuffix := "\n" + UnsubscribeFooter
+	if !strings.HasSuffix(gotBody, wantSuffix) {
+		t.Errorf("posted Body = %q; want suffix %q", gotBody, wantSuffix)
+	}
+	if !strings.HasPrefix(gotBody, "Task bf_123 completed.") {
+		t.Errorf("posted Body did not preserve original text: %q", gotBody)
+	}
+}


### PR DESCRIPTION
## Summary

- Appends `Reply STOP to unsubscribe` on a new line to every outbound SMS, at both Twilio chokepoints:
  - `TwilioMessenger.Send` — REST-API sends used by `MessagingNotifier` for task lifecycle events.
  - `writeTwiML` — TwiML auto-replies sent from the inbound webhook (`Task created: …`, authorization errors, parse errors, etc.).
- Introduces an `UnsubscribeFooter` constant in `internal/messaging/messenger.go` so the footer text lives in one place.
- Adds a small `baseURL` seam to `TwilioMessenger` so the new unit test can target a local `httptest` server without hitting the real Twilio API.

Chosen to live at the Twilio boundary rather than in `formatEventMessage`, so the footer is a transport-level concern and future non-SMS channels (Discord etc.) don't inherit it.

## Why

Regulatory / carrier rules (TCPA, 10DLC) require an unsubscribe instruction on every commercial SMS. Before this change, neither the server-initiated notifications nor the webhook auto-replies included one.

## Test plan

- [x] `go test ./internal/messaging/... ./internal/notify/...` — all pass, including new `TestTwilioMessenger_AppendsUnsubscribeFooter` and updated `TestInboundHandler_AllowedSender` / `TestInboundHandler_RejectedSender` assertions.
- [x] `go test ./...` — only unrelated pre-existing failure is `TestFakeAgentTimeout` (fails on base branch too).
- [x] `gofmt -l internal/messaging/` — clean.
- [x] `go vet ./...` — clean.
- [ ] Manual smoke (optional): inbound SMS to the dev tunnel shows the footer on the auto-reply; a lifecycle notification via `reply_channel: sms:+1…` includes the footer on a new line.