### PR TITLE
Remove unused Slack webhook stub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,13 +127,6 @@ Optional env vars:
 
 At startup, Backflow persists the install config to the `discord_installs` table, registers the `/backflow` slash command (with `create`, `status`, `list`, `cancel`, and `retry` subcommands) via the Discord API, mounts the interaction handler at `/webhooks/discord`, and subscribes a `DiscordNotifier` to the event bus. The `/backflow create` subcommand opens a modal dialog for task creation. The `/backflow cancel <task_id>` and `/backflow retry <task_id>` subcommands cancel or retry tasks respectively, with role-based permission enforcement via `BACKFLOW_DISCORD_ALLOWED_ROLES`. The notifier creates a channel message on the first event for each task, then posts subsequent events as replies in a per-task thread. Thread messages include Cancel buttons for active tasks and Retry buttons for failed/interrupted tasks (cancelled tasks show a Retry button only after container cleanup completes).
 
-### Slack notification stub
-
-- `BACKFLOW_SLACK_WEBHOOK_URL`
-- `BACKFLOW_SLACK_EVENTS` (comma-separated event filter)
-
-If the Slack webhook URL is set, `cmd/backflow/main.go` logs that the subscriber is not yet implemented.
-
 ## Reading mode
 
 When a task's `task_mode` is `read`, the orchestrator selects `BACKFLOW_READER_IMAGE` instead of the default agent image. The reader container fetches the URL in the prompt, drafts a summary, and emits structured JSON (url/title/tldr/tags/connections/novelty_verdict/etc.) to `status.json` (and a `BACKFLOW_STATUS_JSON:` log line for Fargate).

--- a/cmd/backflow/main.go
+++ b/cmd/backflow/main.go
@@ -103,7 +103,6 @@ func main() {
 		bus.Subscribe(notify.NewWebhookNotifier(cfg.WebhookURL, cfg.WebhookEvents))
 		log.Info().Str("url", cfg.WebhookURL).Msg("webhook notifications enabled")
 	}
-	logConfiguredNotificationChannels(cfg)
 
 	// Initialize messaging
 	var messenger messaging.Messenger
@@ -310,10 +309,4 @@ func hasActiveTasks(ctx context.Context, db store.Store) bool {
 		}
 	}
 	return false
-}
-
-func logConfiguredNotificationChannels(cfg *config.Config) {
-	if cfg.SlackWebhookURL != "" {
-		log.Info().Msg("slack notifications configured but subscriber not yet implemented")
-	}
 }

--- a/cmd/backflow/main_test.go
+++ b/cmd/backflow/main_test.go
@@ -1,40 +1,10 @@
 package main
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-
-	"github.com/backflow-labs/backflow/internal/config"
 )
-
-func TestLogConfiguredNotificationChannels(t *testing.T) {
-	var buf bytes.Buffer
-	orig := log.Logger
-	log.Logger = zerolog.New(&buf)
-	t.Cleanup(func() {
-		log.Logger = orig
-	})
-
-	cfg := &config.Config{
-		SlackWebhookURL: "https://hooks.slack.com/services/test",
-	}
-
-	logConfiguredNotificationChannels(cfg)
-
-	out := buf.String()
-	if !strings.Contains(out, "slack notifications configured but subscriber not yet implemented") {
-		t.Fatalf("log output missing Slack placeholder message: %s", out)
-	}
-	if strings.Contains(out, cfg.SlackWebhookURL) {
-		t.Fatalf("log output leaked Slack URL: %s", out)
-	}
-}
 
 func TestSetupLogger_StderrOnly(t *testing.T) {
 	logger, closer, err := setupLogger("")

--- a/docs/reviews/general-review.md
+++ b/docs/reviews/general-review.md
@@ -187,7 +187,7 @@ Suggested fix: Define a `TaskStore` sub-interface for the API handlers; extend t
 Suggested fix: Define a narrow `inboundStore interface { GetAllowedSender(…); CreateTask(…) }` parameter; pass a `notify.Emitter` for event emission.
 
 **42. `internal/config/config.go:28` — [Struct Field Sprawl]**
-`Config` has ~50 fields spanning AWS EC2, ECS/Fargate, Discord, SMS/Twilio, Slack, S3, GitHub, logging, database, and orchestrator concerns. `Load()` is consequently ~130 lines.
+`Config` has ~50 fields spanning AWS EC2, ECS/Fargate, Discord, SMS/Twilio, S3, GitHub, logging, database, and orchestrator concerns. `Load()` is consequently ~130 lines.
 Suggested fix: Group into embedded sub-structs (`AWSConfig`, `DiscordConfig`, `SMSConfig`) for self-documentation without changing behavior.
 
 **43. `cmd/migrate-to-postgres/main.go:300-306` — [Dead Code]** *(Merged: R1#32 + R2#45)*

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,10 +95,6 @@ type Config struct {
 	SMSEvents          []string
 	SMSOutboundEnabled bool
 
-	// Slack (subscriber implementation is out of scope)
-	SlackWebhookURL string
-	SlackEvents     []string
-
 	// Discord
 	DiscordAppID        string
 	DiscordPublicKey    string
@@ -183,8 +179,6 @@ func Load() (*Config, error) {
 		S3Bucket:                os.Getenv("BACKFLOW_S3_BUCKET"),
 		GitHubToken:             os.Getenv("GITHUB_TOKEN"),
 		WebhookURL:              os.Getenv("BACKFLOW_WEBHOOK_URL"),
-		SlackWebhookURL:         os.Getenv("BACKFLOW_SLACK_WEBHOOK_URL"),
-		SlackEvents:             envCSV("BACKFLOW_SLACK_EVENTS"),
 		DiscordAppID:            os.Getenv("BACKFLOW_DISCORD_APP_ID"),
 		DiscordPublicKey:        os.Getenv("BACKFLOW_DISCORD_PUBLIC_KEY"),
 		DiscordBotToken:         os.Getenv("BACKFLOW_DISCORD_BOT_TOKEN"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,34 +37,19 @@ func TestLoad_DefaultModel(t *testing.T) {
 	if cfg.DefaultCodexModel == "" {
 		t.Error("DefaultCodexModel is empty")
 	}
-	if cfg.SlackEvents != nil {
-		t.Errorf("SlackEvents = %#v, want nil when unset", cfg.SlackEvents)
-	}
 	if cfg.DiscordEvents != nil {
 		t.Errorf("DiscordEvents = %#v, want nil when unset", cfg.DiscordEvents)
 	}
 }
 
-func TestLoad_SlackAndDiscordEvents(t *testing.T) {
+func TestLoad_DiscordEvents(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
 	t.Setenv("BACKFLOW_DATABASE_URL", "postgres://user:pass@localhost:5432/db")
-	t.Setenv("BACKFLOW_SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/test")
-	t.Setenv("BACKFLOW_SLACK_EVENTS", "task.created, task.completed ,task.failed")
 	t.Setenv("BACKFLOW_DISCORD_EVENTS", "task.running, task.interrupted")
 
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load() returned error: %v", err)
-	}
-
-	wantSlack := []string{"task.created", "task.completed", "task.failed"}
-	if len(cfg.SlackEvents) != len(wantSlack) {
-		t.Fatalf("SlackEvents length = %d, want %d", len(cfg.SlackEvents), len(wantSlack))
-	}
-	for i := range wantSlack {
-		if cfg.SlackEvents[i] != wantSlack[i] {
-			t.Fatalf("SlackEvents[%d] = %q, want %q", i, cfg.SlackEvents[i], wantSlack[i])
-		}
 	}
 
 	wantDiscord := []string{"task.running", "task.interrupted"}


### PR DESCRIPTION
## Summary

`BACKFLOW_SLACK_WEBHOOK_URL` has been a stub since introduction — setting it only produced a log line saying "subscriber not yet implemented." This removes the config surface and associated docs so the codebase reflects what Backflow actually supports (generic webhook + Discord + SMS).

- Dropped `SlackWebhookURL` / `SlackEvents` fields from `internal/config/config.go` (struct + `Load()`).
- Removed `logConfiguredNotificationChannels` and its call from `cmd/backflow/main.go`, plus the matching test in `main_test.go`.
- Trimmed the Slack-specific assertions in `internal/config/config_test.go`; the renamed `TestLoad_DiscordEvents` keeps the Discord coverage.
- Deleted the "Slack notification stub" section from `CLAUDE.md` and the Slack mention in `docs/reviews/general-review.md`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed files — clean
- [x] `go test ./internal/config/... ./cmd/backflow/...` passes