### PR TITLE
Accept reading-mode tasks via POST /tasks (#175)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,10 +2,16 @@
 
 Ledger of cross-PR tradeoffs. Each entry: decision → consequence for downstream work.
 
+## #175 — REST API reading task creation
+
+- **`task_mode` allow-list: `""`, `"auto"`, `"read"`.** Explicit `"code"` / `"review"` rejected — prompt inference is still the only path. Loosen `CreateTaskRequest.Validate` if a future caller needs explicit opt-in.
+- **Read dispatch lives in `api.NewTask`, not the handler.** Discord modal (#176), SMS, and any future caller inherit read-mode support as soon as they pass `task_mode` through.
+- **`FORCE` reserved and always emitted.** Docker and Fargate pass `FORCE=%t` for every task; non-read tasks get `FORCE=false` (agent ignores).
+
 ## #174 — Reading completion pipeline
 
 - **`Task.Force` added here, not #175.** `models.Task` gains `Force bool` + migration `012_task_force.sql`. #175 is now pure API wiring — add `Force *bool` to `CreateTaskRequest` and copy it in at creation time, no schema work.
 - **`Event.TaskMode` populated in `NewEvent`.** One-line change. #177's Discord reading embed can branch on `event.TaskMode == "read"` without further plumbing. Reading fields (`TLDR`, `NoveltyVerdict`, `Tags`, `Connections`) are also already on the event for read-task completions.
 - **Embeddings client is single-shot, no retries.** Failures surface as task failures; higher-level retry handles transients. Add retries later inside `OpenAIEmbedder` without changing the `Embedder` interface if 429/5xx rates become an issue.
 - **`reading.raw_output` is the marshaled `AgentStatus`, not a separate agent field.** Lossless for typed fields; adding new agent output requires extending `AgentStatus` (two lines).
-- **Deferred:** Discord reading embed formatting (#177), API-level `force` wiring (#175), `GetReadingByURL`/reader accessors (no consumer yet), `SUPABASE_READER_KEY` custom JWT (dead-ended on Supabase side — using publishable key via `SUPABASE_ANON_KEY`, see `docs/supabase-setup.md`).
+- **Deferred:** Discord reading embed formatting (#177), `GetReadingByURL`/reader accessors (no consumer yet), `SUPABASE_READER_KEY` custom JWT (dead-ended on Supabase side — using publishable key via `SUPABASE_ANON_KEY`, see `docs/supabase-setup.md`).

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -553,7 +553,7 @@ components:
           $ref: "#/components/schemas/TaskStatus"
         task_mode:
           type: string
-          enum: [auto, code, review]
+          enum: [auto, code, review, read]
           example: auto
         harness:
           type: string
@@ -581,6 +581,14 @@ components:
           type: string
           enum: [low, medium, high, xhigh]
           example: medium
+        agent_image:
+          type: string
+          description: Docker image used by the orchestrator for this task (reader image for read mode, default agent image otherwise).
+          example: "backflow-agent:v1"
+        force:
+          type: boolean
+          description: For read-mode tasks, signals the agent to skip duplicate-detection and the completion handler to upsert instead of insert. No effect for code/review tasks.
+          example: false
         max_budget_usd:
           type: number
           minimum: 0
@@ -686,8 +694,21 @@ components:
       properties:
         prompt:
           type: string
-          description: Task instructions for the agent.
+          description: Task instructions for the agent. For read-mode tasks, the URL to summarize.
           example: "Fix the authentication bug in https://github.com/owner/repo"
+        task_mode:
+          type: string
+          enum: [auto, read]
+          description: >
+            Explicit task mode. Omit (or "auto") to let the agent's Prep stage infer
+            code vs. review from the prompt. Set to "read" to create a reading-mode
+            task (the prompt is the URL to summarize). Explicit "code" and "review"
+            are not accepted — they are always inferred.
+          example: read
+        force:
+          type: boolean
+          description: For read-mode tasks, skip duplicate detection and upsert on completion. No effect for other modes.
+          example: false
         harness:
           type: string
           enum: [claude_code, codex]

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -322,6 +322,71 @@ func TestCreateReviewTask(t *testing.T) {
 	}
 }
 
+func TestCreateReadTask_ViaPOSTTasks(t *testing.T) {
+	ctx := context.Background()
+	if _, err := truncatePool.Exec(ctx, "TRUNCATE tasks, instances, allowed_senders, api_keys CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	_, thisFile, _, _ := runtime.Caller(0)
+	migrationsDir := filepath.Join(filepath.Dir(thisFile), "..", "..", "migrations")
+	s, err := store.NewPostgres(ctx, sharedConnStr, migrationsDir)
+	if err != nil {
+		t.Fatalf("NewPostgres: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	cfg := &config.Config{
+		AnthropicAPIKey:       "sk-test",
+		ReaderImage:           "backflow-reader:v1",
+		DefaultHarness:        "claude_code",
+		DefaultClaudeModel:    "claude-sonnet-4-6",
+		DefaultCodexModel:     "gpt-5.4",
+		DefaultEffort:         "medium",
+		DefaultMaxBudget:      10.0,
+		DefaultMaxRuntime:     30 * 60e9,
+		DefaultMaxTurns:       200,
+		DefaultReadMaxBudget:  0.5,
+		DefaultReadMaxRuntime: 300 * 1e9,
+		DefaultReadMaxTurns:   20,
+	}
+	srv := NewServer(s, cfg, noopLogFetcher{}, noopEmitter{})
+
+	body := `{"prompt":"https://example.com/article","task_mode":"read","force":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	checkResponse(t, req, w)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			ID         string `json:"id"`
+			TaskMode   string `json:"task_mode"`
+			Force      bool   `json:"force"`
+			AgentImage string `json:"agent_image"`
+			CreatePR   bool   `json:"create_pr"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Data.TaskMode != "read" {
+		t.Errorf("task_mode = %q, want read", resp.Data.TaskMode)
+	}
+	if !resp.Data.Force {
+		t.Error("force = false, want true")
+	}
+	if resp.Data.AgentImage != "backflow-reader:v1" {
+		t.Errorf("agent_image = %q, want reader image", resp.Data.AgentImage)
+	}
+	if resp.Data.CreatePR {
+		t.Error("create_pr = true, want false for read mode")
+	}
+}
+
 func TestDeleteTask(t *testing.T) {
 	srv := testServer(t)
 

--- a/internal/api/task_creator.go
+++ b/internal/api/task_creator.go
@@ -27,6 +27,10 @@ func NewTask(ctx context.Context, req *models.CreateTaskRequest, s store.Store, 
 		return nil, err
 	}
 
+	if req.TaskMode != nil && *req.TaskMode == models.TaskModeRead {
+		return NewReadTask(ctx, req, s, cfg, bus)
+	}
+
 	now := time.Now().UTC()
 
 	task := &models.Task{
@@ -38,6 +42,7 @@ func NewTask(ctx context.Context, req *models.CreateTaskRequest, s store.Store, 
 		Context:       req.Context,
 		Model:         req.Model,
 		Effort:        req.Effort,
+		Force:         req.Force != nil && *req.Force,
 		MaxBudgetUSD:  req.MaxBudgetUSD,
 		MaxRuntimeSec: req.MaxRuntimeSec,
 		MaxTurns:      req.MaxTurns,
@@ -93,6 +98,7 @@ func NewReadTask(ctx context.Context, req *models.CreateTaskRequest, s store.Sto
 		Context:       req.Context,
 		Model:         req.Model,
 		Effort:        req.Effort,
+		Force:         req.Force != nil && *req.Force,
 		MaxBudgetUSD:  req.MaxBudgetUSD,
 		MaxRuntimeSec: req.MaxRuntimeSec,
 		MaxTurns:      req.MaxTurns,

--- a/internal/api/task_creator_test.go
+++ b/internal/api/task_creator_test.go
@@ -169,6 +169,129 @@ func TestNewReadTask_ValidationError_NotStoreFailure(t *testing.T) {
 	}
 }
 
+func strPtr(s string) *string { return &s }
+
+// TestNewTask_TaskModeRead_DispatchesToNewReadTask verifies the REST API entry
+// point: clients who pass task_mode="read" get a reader-mode task without the
+// handler having to know about NewReadTask.
+func TestNewTask_TaskModeRead_DispatchesToNewReadTask(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{}
+	req := &models.CreateTaskRequest{
+		Prompt:   "https://example.com/post",
+		TaskMode: strPtr("read"),
+	}
+
+	task, err := NewTask(context.Background(), req, s, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewTask: %v", err)
+	}
+	if task.TaskMode != models.TaskModeRead {
+		t.Errorf("TaskMode = %q, want %q", task.TaskMode, models.TaskModeRead)
+	}
+	if task.AgentImage != "backflow-reader:v1" {
+		t.Errorf("AgentImage = %q, want reader image", task.AgentImage)
+	}
+	if task.CreatePR {
+		t.Error("CreatePR = true, want false for read mode")
+	}
+	if task.MaxBudgetUSD != 0.5 {
+		t.Errorf("MaxBudgetUSD = %v, want 0.5 (read cap)", task.MaxBudgetUSD)
+	}
+	if task.MaxRuntimeSec != 300 {
+		t.Errorf("MaxRuntimeSec = %d, want 300 (read cap)", task.MaxRuntimeSec)
+	}
+	if task.MaxTurns != 20 {
+		t.Errorf("MaxTurns = %d, want 20 (read cap)", task.MaxTurns)
+	}
+}
+
+func TestNewTask_ExplicitCodeOrReviewTaskMode_Rejected(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{}
+	for _, mode := range []string{"code", "review"} {
+		t.Run(mode, func(t *testing.T) {
+			req := &models.CreateTaskRequest{
+				Prompt:   "Fix bug",
+				TaskMode: strPtr(mode),
+			}
+			_, err := NewTask(context.Background(), req, s, cfg, nil)
+			if err == nil {
+				t.Fatalf("task_mode=%q: expected validation error, got nil", mode)
+			}
+			if !contains(err.Error(), "inferred") {
+				t.Errorf("task_mode=%q: error = %q, want mention of 'inferred'", mode, err.Error())
+			}
+		})
+	}
+}
+
+func TestNewTask_InvalidTaskMode_ValidationError(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{}
+	req := &models.CreateTaskRequest{
+		Prompt:   "Fix bug",
+		TaskMode: strPtr("garbage"),
+	}
+
+	_, err := NewTask(context.Background(), req, s, cfg, nil)
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if errors.Is(err, ErrStoreFailure) {
+		t.Errorf("validation error should not match ErrStoreFailure, got: %v", err)
+	}
+	if msg := err.Error(); !contains(msg, "task_mode") {
+		t.Errorf("error = %q, want message mentioning task_mode", msg)
+	}
+}
+
+// contains is a tiny substring helper local to these tests.
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNewTask_CopiesForceFromRequest(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{}
+	trueVal := true
+	req := &models.CreateTaskRequest{
+		Prompt: "Fix bug",
+		Force:  &trueVal,
+	}
+
+	task, err := NewTask(context.Background(), req, s, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewTask: %v", err)
+	}
+	if !task.Force {
+		t.Error("Force = false, want true for non-read task with force=true")
+	}
+}
+
+func TestNewReadTask_CopiesForceFromRequest(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{}
+	trueVal := true
+	req := &models.CreateTaskRequest{
+		Prompt: "https://example.com/post",
+		Force:  &trueVal,
+	}
+
+	task, err := NewReadTask(context.Background(), req, s, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewReadTask: %v", err)
+	}
+	if !task.Force {
+		t.Error("Force = false, want true")
+	}
+}
+
 // TestNewReadTask_IgnoresPRFields pins the documented contract that read
 // tasks never open PRs. A future refactor must not silently start honoring
 // PRTitle, PRBody, CreatePR, or SelfReview.

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -118,6 +118,7 @@ func (t *Task) EnvVarsJSON() string {
 // infers repo_url, target_branch, and task_mode from the prompt.
 type CreateTaskRequest struct {
 	Prompt          string            `json:"prompt"`
+	TaskMode        *string           `json:"task_mode,omitempty"`
 	Harness         string            `json:"harness,omitempty"`
 	Context         string            `json:"context,omitempty"`
 	Model           string            `json:"model,omitempty"`
@@ -128,6 +129,7 @@ type CreateTaskRequest struct {
 	CreatePR        *bool             `json:"create_pr,omitempty"`
 	SelfReview      *bool             `json:"self_review,omitempty"`
 	SaveAgentOutput *bool             `json:"save_agent_output,omitempty"`
+	Force           *bool             `json:"force,omitempty"`
 	PRTitle         string            `json:"pr_title,omitempty"`
 	PRBody          string            `json:"pr_body,omitempty"`
 	AllowedTools    []string          `json:"allowed_tools,omitempty"`
@@ -155,6 +157,7 @@ var reservedEnvVarKeys = map[string]bool{
 	"MAX_TURNS":         true,
 	"CREATE_PR":         true,
 	"SELF_REVIEW":       true,
+	"FORCE":             true,
 	"PR_TITLE":          true,
 	"PR_BODY":           true,
 	"CLAUDE_MD":         true,
@@ -224,6 +227,13 @@ func (r *CreateTaskRequest) Validate() error {
 		case "low", "medium", "high", "xhigh":
 		default:
 			return fmt.Errorf("effort must be low, medium, high, or xhigh")
+		}
+	}
+	if r.TaskMode != nil {
+		switch *r.TaskMode {
+		case "", TaskModeAuto, TaskModeRead:
+		default:
+			return fmt.Errorf("task_mode must be auto or read (code and review are inferred from the prompt)")
 		}
 	}
 	return nil

--- a/internal/models/task_test.go
+++ b/internal/models/task_test.go
@@ -213,6 +213,11 @@ func TestCreateTaskRequestValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "reserved env var key FORCE",
+			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"FORCE": "true"}},
+			wantErr: true,
+		},
+		{
 			name:    "non-reserved env var key allowed",
 			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"MY_CUSTOM_VAR": "val"}},
 			wantErr: false,

--- a/internal/orchestrator/docker/docker.go
+++ b/internal/orchestrator/docker/docker.go
@@ -146,6 +146,7 @@ func (m *Manager) buildEnvFlags(task *models.Task) []string {
 		fmt.Sprintf("-e MAX_TURNS=%d", task.MaxTurns),
 		fmt.Sprintf("-e CREATE_PR=%t", task.CreatePR),
 		fmt.Sprintf("-e SELF_REVIEW=%t", task.SelfReview),
+		fmt.Sprintf("-e FORCE=%t", task.Force),
 	}
 
 	if task.PRTitle != "" {

--- a/internal/orchestrator/docker/docker_test.go
+++ b/internal/orchestrator/docker/docker_test.go
@@ -167,6 +167,18 @@ func TestBuildEnvFlags(t *testing.T) {
 	}
 }
 
+func TestBuildEnvFlagsForceFlag(t *testing.T) {
+	dm := NewManager(&config.Config{})
+	for _, force := range []bool{true, false} {
+		task := &models.Task{ID: "bf_x", Prompt: "p", Force: force}
+		joined := strings.Join(dm.buildEnvFlags(task), " ")
+		want := "-e FORCE=" + map[bool]string{true: "true", false: "false"}[force]
+		if !strings.Contains(joined, want) {
+			t.Errorf("force=%v: flags missing %q\ngot: %s", force, want, joined)
+		}
+	}
+}
+
 func TestBuildRunCommand(t *testing.T) {
 	cfg := &config.Config{
 		AnthropicAPIKey: "sk-test",

--- a/internal/orchestrator/fargate/fargate.go
+++ b/internal/orchestrator/fargate/fargate.go
@@ -257,6 +257,7 @@ func (m *Manager) buildECSEnvVars(task *models.Task) []ecstypes.KeyValuePair {
 		ecsEnvVar("MAX_TURNS", strconv.Itoa(task.MaxTurns)),
 		ecsEnvVar("CREATE_PR", strconv.FormatBool(task.CreatePR)),
 		ecsEnvVar("SELF_REVIEW", strconv.FormatBool(task.SelfReview)),
+		ecsEnvVar("FORCE", strconv.FormatBool(task.Force)),
 	}
 
 	if task.PRTitle != "" {

--- a/internal/orchestrator/fargate/fargate_test.go
+++ b/internal/orchestrator/fargate/fargate_test.go
@@ -86,6 +86,25 @@ func TestFargateBuildECSEnvVars(t *testing.T) {
 	}
 }
 
+func TestFargateBuildECSEnvVars_ForceFlag(t *testing.T) {
+	manager := NewManager(&config.Config{}, nil)
+	for _, force := range []bool{true, false} {
+		task := &models.Task{ID: "bf_x", Prompt: "p", Force: force}
+		envVars := manager.buildECSEnvVars(task)
+		got := ""
+		for _, pair := range envVars {
+			if aws.ToString(pair.Name) == "FORCE" {
+				got = aws.ToString(pair.Value)
+				break
+			}
+		}
+		want := map[bool]string{true: "true", false: "false"}[force]
+		if got != want {
+			t.Errorf("force=%v: FORCE env = %q, want %q", force, got, want)
+		}
+	}
+}
+
 func TestFargate_SelectTaskDefinition(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Closes #175.

## Summary

Wires reading-mode tasks into the REST API. `NewReadTask` already existed (#173) and `Task.Force` + its DB column already existed (#174) — this PR is the missing API surface plus the agent-container env-var passthrough.

- **`CreateTaskRequest` gains `task_mode *string` and `force *bool`.** Allowed values for `task_mode`: `""`, `"auto"`, `"read"`. Explicit `"code"` / `"review"` are rejected with a friendly message — prompt inference remains the only path to those modes.
- **`api.NewTask` dispatches to `NewReadTask` when `task_mode=="read"`.** Dispatch lives in the shared helper (not the HTTP handler), so Discord modal (#176), SMS, and any future caller inherit read-mode support as soon as they populate `task_mode`.
- **`Force` is copied from the request onto the task** in both `NewTask` and `NewReadTask`.
- **`FORCE` is now a reserved env var key** (blocks user-supplied `env_vars.FORCE`) and is unconditionally emitted for every task by the Docker runner (`-e FORCE=%t`) and the Fargate runner (`ecsEnvVar("FORCE", ...)`). Non-read tasks get `FORCE=false`; agents ignore it.
- **OpenAPI spec updated:** `Task.task_mode` enum gains `"read"`; `Task` gets `agent_image` and `force` properties; `CreateTaskRequest` documents `task_mode` (auto|read) and `force`.
- **HANDOFF.md:** records the `task_mode` allow-list decision and the unconditional `FORCE` env var; removes the now-fulfilled "API-level force wiring (#175)" item from #174's Deferred list.

## Acceptance criteria (from #175)

- [x] `POST /tasks` with `{"task_mode":"read","prompt":"https://example.com/article"}` creates a task with `task_mode=read` (integration test: `TestCreateReadTask_ViaPOSTTasks`)
- [x] `force` is accepted on `CreateTaskRequest` and persisted on the task
- [x] Reading-specific defaults (budget, runtime, turns, agent image) applied
- [x] `create_pr` / `self_review` / `pr_title` / `pr_body` ignored for read tasks (pinned by existing `TestNewReadTask_IgnoresPRFields`)
- [x] Existing code/review task creation unaffected
- [x] `force` passed through to the agent container as `FORCE` env var

## Test plan

- [x] `go test ./internal/api/...` — new TDD tests for dispatch, force copy, invalid / explicit task_mode rejection, and HTTP integration
- [x] `go test ./internal/models/...` — new reserved-env-var test for `FORCE`
- [x] `go test ./internal/orchestrator/docker/...` — new `TestBuildEnvFlagsForceFlag`
- [x] `go test ./internal/orchestrator/fargate/...` — new `TestFargateBuildECSEnvVars_ForceFlag`
- [x] `make lint` clean
- [x] `make test` green across all packages
- [ ] Optional: `make test-blackbox` before merge to exercise API + orchestrator end-to-end