### PR TITLE
Add test for reading completed with empty novelty verdict

### DIFF
--- a/internal/notify/discord_test.go
+++ b/internal/notify/discord_test.go
@@ -414,6 +414,26 @@ func TestDiscordEmbedFormatting(t *testing.T) {
 		}
 	})
 
+	t.Run("reading completed empty verdict", func(t *testing.T) {
+		embed := discordEmbedForEvent(Event{
+			Type:      EventTaskCompleted,
+			TaskID:    "bf_r5",
+			TaskMode:  "read",
+			TLDR:      "Overview of Go concurrency patterns",
+			Timestamp: time.Now().UTC(),
+		})
+
+		if embed.Title != "Reading completed" {
+			t.Fatalf("Title = %q, want %q", embed.Title, "Reading completed")
+		}
+		if embed.Color != 0x57F287 {
+			t.Fatalf("Color = %#x, want 0x57F287 (green)", embed.Color)
+		}
+		if containsField(embed.Fields, "Verdict", "") {
+			t.Fatal("embed should not have Verdict field when NoveltyVerdict is empty")
+		}
+	})
+
 	t.Run("reading failed shows reading-specific title", func(t *testing.T) {
 		embed := discordEmbedForEvent(Event{
 			Type:         EventTaskFailed,


### PR DESCRIPTION
## Summary

- Adds a `"reading completed empty verdict"` subtest to `TestDiscordEmbedFormatting`
- Verifies that when `TaskMode=read` and `NoveltyVerdict` is empty, the embed uses title "Reading completed", green color (`0x57F287`), and no "Verdict" field

## Test plan

- [x] `go test ./internal/notify/ -run TestDiscordEmbedFormatting/reading_completed_empty_verdict -v` passes

https://claude.ai/code/session_01919FmksepFRpiySaFmkt7g