### PR TITLE
Document reading mode across CLAUDE.md and discord-setup.md (#178)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,9 @@ Two goroutines: chi REST API on `:8080` + polling orchestrator (5s default). Thr
 - **api/** — chi router, handlers, JSON responses, `LogFetcher` interface, `NewTask` shared task-creation helper (used by both REST handler and Discord modal), `CancelTask` and `RetryTask` shared action helpers (used by both REST handler and Discord)
 - **orchestrator/** — Poll loop (`orchestrator.go`), dispatch (`dispatch.go`), monitoring (`monitor.go`, including `handleReadingCompletion` for read-mode tasks), recovery (`recovery.go`), local mode (`local.go`). Subpackages: `docker/` (Docker container management via SSM or local exec), `ec2/` (EC2 lifecycle, auto-scaler, spot interruption handler), `fargate/` (ECS/Fargate runner, CloudWatch log parsing), `s3/` (agent output upload)
 - **store/** — `Store` interface + PostgreSQL (`pgxpool`, goose migrations). Includes `CreateReading` / `UpsertReading` for the `readings` table.
-- **models/** — `Task`, `Instance`, `AllowedSender`, `DiscordInstall`, and `Reading` (+ `Connection`) structs with status enums. `FindFirstURL` / `InferReviewMode` auto-detect review mode when a prompt's first URL is a GitHub PR URL.
+- **models/** — `Task`, `Instance`, `AllowedSender`, `DiscordInstall`, and `Reading` (+ `Connection`) structs with status enums. `Task.AgentImage` records which Docker image the orchestrator used (read tasks get `ReaderImage`, others get the default agent image). `FindFirstURL` / `InferReviewMode` auto-detect review mode when a prompt's first URL is a GitHub PR URL.
 - **embeddings/** — Thin `Embedder` interface (`Embed(ctx, text) ([]float32, error)`) with an `OpenAIEmbedder` HTTP client (no SDK). Used by the orchestrator to embed a reading's final TL;DR before writing the `readings` row.
-- **discord/** — Discord interaction handler (Ed25519 signature verification, PING/PONG, interaction routing, `/backflow create` modal for task creation, `/backflow cancel` and `/backflow retry` commands, button click handling). `HandlerActions` struct groups callback functions and role-based authorization config.
+- **discord/** — Discord interaction handler (Ed25519 signature verification, PING/PONG, interaction routing, `/backflow create` modal for task creation, `/backflow read <url> [force]` for reading-mode task creation, `/backflow cancel` and `/backflow retry` commands, button click handling). `HandlerActions` struct groups callback functions and role-based authorization config.
 - **config/** — Env-var config (`BACKFLOW_*` prefix), three modes (`ec2`/`local`/`fargate`). `RestrictAPI` blocks all `/api/v1/*` endpoints when `BACKFLOW_RESTRICT_API=true` (used in Fly.io deployment). `BACKFLOW_API_KEY` enables single-token API auth; otherwise `api_keys` in Postgres can back authenticated API/debug requests. `TaskDefaults(taskMode)` returns resolved defaults — for `read` mode it swaps in `ReaderImage` plus the `BACKFLOW_DEFAULT_READ_MAX_*` caps. `Apply(task, overrides)` fills zero-value fields using `*bool` overrides (nil = use default, non-nil = use pointed value)
 - **notify/** — `Notifier` interface, `WebhookNotifier` (HTTP POST, 3 retries, event filtering), `DiscordNotifier` (lifecycle messages in channel + per-task threads), `NoopNotifier`, `EventBus` (async fan-out delivery via buffered channel), `NewEvent` constructor with `EventOption` functional options (including `WithReading` for read-mode completion events), `MessagingNotifier` (SMS via Twilio for reply channels). `Event` carries `TaskMode` plus optional reading fields (`TLDR`, `NoveltyVerdict`, `Tags`, `Connections`) populated only for read-task completion events.
 - **messaging/** — `Messenger` interface, `TwilioMessenger` (outbound SMS), inbound SMS webhook handler, message parsing
@@ -125,7 +125,7 @@ Optional env vars:
 - `BACKFLOW_DISCORD_ALLOWED_ROLES` (comma-separated role IDs for mutation authorization)
 - `BACKFLOW_DISCORD_EVENTS` (comma-separated event filter; nil = all events)
 
-At startup, Backflow persists the install config to the `discord_installs` table, registers the `/backflow` slash command (with `create`, `status`, `list`, `cancel`, and `retry` subcommands) via the Discord API, mounts the interaction handler at `/webhooks/discord`, and subscribes a `DiscordNotifier` to the event bus. The `/backflow create` subcommand opens a modal dialog for task creation. The `/backflow cancel <task_id>` and `/backflow retry <task_id>` subcommands cancel or retry tasks respectively, with role-based permission enforcement via `BACKFLOW_DISCORD_ALLOWED_ROLES`. The notifier creates a channel message on the first event for each task, then posts subsequent events as replies in a per-task thread. Thread messages include Cancel buttons for active tasks and Retry buttons for failed/interrupted tasks (cancelled tasks show a Retry button only after container cleanup completes).
+At startup, Backflow persists the install config to the `discord_installs` table, registers the `/backflow` slash command (with `create`, `status`, `list`, `cancel`, `retry`, and `read` subcommands) via the Discord API, mounts the interaction handler at `/webhooks/discord`, and subscribes a `DiscordNotifier` to the event bus. The `/backflow create` subcommand opens a modal dialog for task creation. The `/backflow read <url> [force]` subcommand creates a `task_mode=read` task for the given URL; the optional `force` flag bypasses the exact-URL duplicate check and upserts the existing reading on completion. The `/backflow cancel <task_id>` and `/backflow retry <task_id>` subcommands cancel or retry tasks respectively. All mutation commands enforce role-based permissions via `BACKFLOW_DISCORD_ALLOWED_ROLES`. The notifier creates a channel message on the first event for each task, then posts subsequent events as replies in a per-task thread. Thread messages include Cancel buttons for active tasks and Retry buttons for failed/interrupted tasks (cancelled tasks show a Retry button only after container cleanup completes).
 
 ## Reading mode
 
@@ -140,7 +140,16 @@ On completion, the orchestrator's `handleReadingCompletion` helper (in `internal
 
 If the embedding API call or the DB write fails, the task is marked `failed` rather than silently `completed`, and `task.failed` is emitted. If `embedder` is nil (no `OPENAI_API_KEY` configured), reading tasks fail at completion.
 
-The reading agent image and reader-side shell scripts live in `docker/reader/`; see `docs/supabase-setup.md` for the PostgREST-backed similarity-search path the agent uses during its session.
+The reading agent image and reader-side shell scripts live in `docker/reader/`:
+
+- `reader-entrypoint.sh` — Image entrypoint: runs the harness, extracts JSON via `reader_helpers.sh`, writes `status.json` via `status_writer.sh`, emits `BACKFLOW_STATUS_JSON:` for Fargate.
+- `read-embed.sh` — Embeds text via OpenAI `text-embedding-3-small`. Used by the agent to embed a draft TL;DR for similarity search.
+- `read-similar.sh` — Semantic similarity search: embeds input text, calls the `reader.match_readings` RPC via PostgREST.
+- `read-lookup.sh` — Exact-URL duplicate check via PostgREST.
+- `reader_helpers.sh` — JSON extraction helpers (pulls the first JSON object from the agent transcript).
+- `status_writer.sh` — Shared helper for writing `status.json` and the Fargate `BACKFLOW_STATUS_JSON:` log line.
+
+See `docs/supabase-setup.md` for the PostgREST-backed similarity-search path the agent uses during its session.
 
 Reading-mode env vars:
 
@@ -222,7 +231,7 @@ In Docker mode, secrets (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GITHUB_TOKEN`) 
 
 ## Database
 
-PostgreSQL via Supabase (session pooler). Migrations are managed by [goose](https://github.com/pressly/goose) and live in `migrations/`. The store implementation is in `internal/store/postgres.go` using `pgxpool`. Set `BACKFLOW_DATABASE_URL` to the Supabase session pooler connection string.
+PostgreSQL via Supabase (session pooler). Tables: `tasks`, `instances`, `allowed_senders`, `api_keys`, `readings`, `discord_installs`, `discord_task_threads`. See `docs/schema.md` for the full column-level schema. Migrations are managed by [goose](https://github.com/pressly/goose) and live in `migrations/`. The store implementation is in `internal/store/postgres.go` using `pgxpool`. Set `BACKFLOW_DATABASE_URL` to the Supabase session pooler connection string.
 
 Migration workflow:
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -11,4 +11,4 @@ Ledger of cross-PR tradeoffs. Each entry: decision → consequence for downstrea
 - **`Event.TaskMode` populated in `NewEvent`.** #177's Discord reading embed can branch on `event.TaskMode == "read"` without further plumbing. Reading fields (`TLDR`, `NoveltyVerdict`, `Tags`, `Connections`) are also already on the event for read-task completions.
 - **Embeddings client is single-shot, no retries.** Failures surface as task failures; higher-level retry handles transients. Add retries later inside `OpenAIEmbedder` without changing the `Embedder` interface if 429/5xx rates become an issue.
 - **`reading.raw_output` is the marshaled `AgentStatus`, not a separate agent field.** Lossless for typed fields; adding new agent output requires extending `AgentStatus` (two lines).
-- **Deferred:** Discord reading embed formatting (#177), `GetReadingByURL`/reader accessors (no consumer yet), `SUPABASE_READER_KEY` custom JWT (dead-ended on Supabase side — using publishable key via `SUPABASE_ANON_KEY`, see `docs/supabase-setup.md`).
+- **Deferred:** `GetReadingByURL`/reader accessors (no consumer yet).

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,14 +1,3 @@
 # HANDOFF.md
 
 Ledger of cross-PR tradeoffs. Each entry: decision → consequence for downstream work.
-
-## #175 — REST API reading task creation
-
-- **`task_mode` allow-list: `""`, `"auto"`, `"read"`.** Explicit `"code"` / `"review"` rejected — prompt inference is still the only path. Loosen `CreateTaskRequest.Validate` if a future caller needs explicit opt-in.
-
-## #174 — Reading completion pipeline
-
-- **`Event.TaskMode` populated in `NewEvent`.** #177's Discord reading embed can branch on `event.TaskMode == "read"` without further plumbing. Reading fields (`TLDR`, `NoveltyVerdict`, `Tags`, `Connections`) are also already on the event for read-task completions.
-- **Embeddings client is single-shot, no retries.** Failures surface as task failures; higher-level retry handles transients. Add retries later inside `OpenAIEmbedder` without changing the `Embedder` interface if 429/5xx rates become an issue.
-- **`reading.raw_output` is the marshaled `AgentStatus`, not a separate agent field.** Lossless for typed fields; adding new agent output requires extending `AgentStatus` (two lines).
-- **Deferred:** `GetReadingByURL`/reader accessors (no consumer yet).

--- a/docs/discord-setup.md
+++ b/docs/discord-setup.md
@@ -76,9 +76,11 @@ The endpoint must be publicly reachable over HTTPS. For local development, use `
 
 **Install state persistence:** At startup, Backflow writes the Discord configuration to the `discord_installs` table in PostgreSQL. This ensures the integration survives service restarts without losing context about which guild/channel to target.
 
-**Slash command registration:** At startup, Backflow registers a `/backflow` slash command with `create`, `status`, `list`, `cancel`, and `retry` subcommands via the Discord bulk-overwrite endpoint. This happens automatically when `BACKFLOW_DISCORD_APP_ID` is set — no manual command creation is needed in the Developer Portal.
+**Slash command registration:** At startup, Backflow registers a `/backflow` slash command with `create`, `status`, `list`, `cancel`, `retry`, and `read` subcommands via the Discord bulk-overwrite endpoint. This happens automatically when `BACKFLOW_DISCORD_APP_ID` is set — no manual command creation is needed in the Developer Portal.
 
 **Task creation via Discord:** The `/backflow create` subcommand opens a modal dialog where users can fill in a repository URL, task description, branch, harness, and max budget. Submitting the modal creates a task and responds with a confirmation embed.
+
+**Reading:** `/backflow read <url> [force]` creates a `task_mode=read` task for the given URL. The `url` parameter is required and validated (must be HTTPS with a valid host). The optional `force` flag bypasses the exact-URL duplicate check — if the URL already has a reading, force causes an upsert on completion. Role-based permissions apply via `BACKFLOW_DISCORD_ALLOWED_ROLES`.
 
 **Cancel and retry:** `/backflow cancel <task_id>` cancels a running task; `/backflow retry <task_id>` requeues a failed, interrupted, or cancelled task. Both commands enforce role-based permissions via `BACKFLOW_DISCORD_ALLOWED_ROLES` — if roles are configured, only users with at least one matching role can execute these commands. If no roles are configured, all users are permitted. All cancel/retry responses are ephemeral (visible only to the invoking user).
 


### PR DESCRIPTION
## Summary

- Add `/backflow read <url> [force]` to Discord subcommand lists in CLAUDE.md and `docs/discord-setup.md`
- Enumerate all 6 reader shell scripts (`reader-entrypoint.sh`, `read-embed.sh`, `read-similar.sh`, `read-lookup.sh`, `reader_helpers.sh`, `status_writer.sh`) in CLAUDE.md's Reading mode section
- Add `Task.AgentImage` to the models module description in CLAUDE.md
- Add table list and `docs/schema.md` cross-reference to the Database section in CLAUDE.md
- Prune completed deferrals from HANDOFF.md (Discord reading embed #177 done, SUPABASE_READER_KEY dead-ended and documented)

**Note on acceptance criteria:** The issue's criteria for `backflow_reader` role and JWT minting instructions are satisfied by an alternative approach — Supabase uses ES256 (asymmetric), so custom JWTs can't be minted. The project uses the Supabase publishable key (`SUPABASE_ANON_KEY`) instead. This is fully documented in `docs/supabase-setup.md`. `docs/schema.md` and `README.md` were already updated in prior PRs.

Closes #178

## Test plan

- [ ] Verify no stale Discord subcommand lists remain: `grep -rn "create.*status.*list.*cancel.*retry" *.md docs/*.md` should show `read` in all active docs
- [ ] Verify `/backflow read` is referenced: `grep -rn "backflow read" CLAUDE.md docs/discord-setup.md`
- [ ] Read through CLAUDE.md, `docs/discord-setup.md`, and HANDOFF.md for coherence