### PR TITLE
Improve 'new' verdict description in reading-completed Discord embed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Three task modes: `code` (default: clone → code → commit → PR), `review` (
 `HANDOFF.md` at the repo root captures cross-PR tradeoffs and decisions that aren't obvious from the diff alone — what was deferred, what was unblocked for future issues, and why an alternative was rejected.
 
 - **Before writing a plan:** read `HANDOFF.md` and weigh any notes that apply to the current task. Prior decisions may constrain or inform the approach.
-- **When writing a plan:** add brief notes to `HANDOFF.md` about explicit tradeoffs decided for this change — especially any decisions the user expressed directly (e.g. "add Force now vs defer to #175"). Record the decision, the alternatives considered, and the consequence for downstream work. Keep each entry tight; this file is a ledger, not a design doc.
+- **When writing a plan:** add brief notes to `HANDOFF.md` about explicit tradeoffs decided for this change — especially any decisions the user expressed directly (e.g. "add Force now vs defer to #175"). Record the decision, the alternatives considered, and the consequence for downstream work. Keep each entry tight; this file is a ledger, not a design doc. Items should be limited to forward-looking constraints or explicit deferrals that a subsequent issue will need to know about.
 
 ## Commands
 

--- a/internal/notify/discord.go
+++ b/internal/notify/discord.go
@@ -348,7 +348,11 @@ func readingCompletedContent(event Event) (string, []discord.EmbedField, int) {
 			}
 			fields = append(fields, discord.EmbedField{Name: "Connections", Value: truncate(strings.Join(lines, "\n"), maxEmbedTextLength), Inline: false})
 		}
-		return fmt.Sprintf("Task %s reading completed.", event.TaskID), fields, 0x57F287
+		desc := "New reading saved."
+		if event.Prompt != "" {
+			desc = fmt.Sprintf("New reading saved: %s", event.Prompt)
+		}
+		return desc, fields, 0x57F287
 	}
 }
 

--- a/internal/notify/discord.go
+++ b/internal/notify/discord.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -190,8 +191,14 @@ func discordTitleForEvent(event Event) string {
 	case EventTaskRunning:
 		return "Task running"
 	case EventTaskCompleted:
+		if event.TaskMode == models.TaskModeRead {
+			return "Reading completed"
+		}
 		return "Task completed"
 	case EventTaskFailed:
+		if event.TaskMode == models.TaskModeRead {
+			return "Reading failed"
+		}
 		return "Task failed"
 	case EventTaskInterrupted:
 		return "Task interrupted"
@@ -229,6 +236,9 @@ func discordEmbedContent(event Event) (string, []discord.EmbedField, int) {
 			{Name: "Task", Value: event.TaskID, Inline: true},
 		}, 0x57F287
 	case EventTaskCompleted:
+		if event.TaskMode == models.TaskModeRead {
+			return readingCompletedContent(event)
+		}
 		fields := []discord.EmbedField{
 			{Name: "Task", Value: event.TaskID, Inline: true},
 		}
@@ -240,9 +250,13 @@ func discordEmbedContent(event Event) (string, []discord.EmbedField, int) {
 		}
 		return fmt.Sprintf("Task %s completed.", event.TaskID), fields, 0x57F287
 	case EventTaskFailed:
-		desc := fmt.Sprintf("Task %s failed.", event.TaskID)
+		noun := "Task"
+		if event.TaskMode == models.TaskModeRead {
+			noun = "Reading"
+		}
+		desc := fmt.Sprintf("%s %s failed.", noun, event.TaskID)
 		if event.RetryLimitReached {
-			desc = fmt.Sprintf("Task %s failed. Retry limit reached.", event.TaskID)
+			desc = fmt.Sprintf("%s %s failed. Retry limit reached.", noun, event.TaskID)
 		}
 		fields := []discord.EmbedField{
 			{Name: "Task", Value: event.TaskID, Inline: true},
@@ -291,6 +305,50 @@ func discordEmbedContent(event Event) (string, []discord.EmbedField, int) {
 		return fmt.Sprintf("Task %s: %s", event.TaskID, event.Type), []discord.EmbedField{
 			{Name: "Task", Value: event.TaskID, Inline: true},
 		}, 0x95A5A6
+	}
+}
+
+func readingCompletedContent(event Event) (string, []discord.EmbedField, int) {
+	fields := []discord.EmbedField{
+		{Name: "Task", Value: event.TaskID, Inline: true},
+	}
+
+	switch event.NoveltyVerdict {
+	case "duplicate":
+		if event.TLDR != "" {
+			fields = append(fields, discord.EmbedField{Name: "TL;DR", Value: truncate(event.TLDR, maxEmbedTextLength), Inline: false})
+		}
+		return "Already read this — here's what you captured:", fields, 0x95A5A6
+
+	case "nothing new":
+		if event.TLDR != "" {
+			fields = append(fields, discord.EmbedField{Name: "TL;DR", Value: truncate(event.TLDR, maxEmbedTextLength), Inline: false})
+		}
+		if len(event.Connections) > 0 {
+			c := event.Connections[0]
+			fields = append(fields, discord.EmbedField{Name: "Most Similar", Value: truncate(fmt.Sprintf("**%s** — %s", c.ReadingID, c.Reason), maxEmbedTextLength), Inline: false})
+		}
+		return "Nothing new here.", fields, 0x95A5A6
+
+	default:
+		// "new" or unrecognized verdict — full embed.
+		if event.NoveltyVerdict != "" {
+			fields = append(fields, discord.EmbedField{Name: "Verdict", Value: event.NoveltyVerdict, Inline: true})
+		}
+		if event.TLDR != "" {
+			fields = append(fields, discord.EmbedField{Name: "TL;DR", Value: truncate(event.TLDR, maxEmbedTextLength), Inline: false})
+		}
+		if len(event.Tags) > 0 {
+			fields = append(fields, discord.EmbedField{Name: "Tags", Value: strings.Join(event.Tags, ", "), Inline: false})
+		}
+		if len(event.Connections) > 0 {
+			var lines []string
+			for _, c := range event.Connections {
+				lines = append(lines, fmt.Sprintf("**%s** — %s", c.ReadingID, c.Reason))
+			}
+			fields = append(fields, discord.EmbedField{Name: "Connections", Value: truncate(strings.Join(lines, "\n"), maxEmbedTextLength), Inline: false})
+		}
+		return fmt.Sprintf("Task %s reading completed.", event.TaskID), fields, 0x57F287
 	}
 }
 

--- a/internal/notify/discord_test.go
+++ b/internal/notify/discord_test.go
@@ -319,6 +319,7 @@ func TestDiscordEmbedFormatting(t *testing.T) {
 			Type:           EventTaskCompleted,
 			TaskID:         "bf_r1",
 			TaskMode:       "read",
+			Prompt:         "https://example.com/article",
 			TLDR:           "Article explains how transformers work",
 			NoveltyVerdict: "new",
 			Tags:           []string{"ml", "transformers"},
@@ -330,6 +331,10 @@ func TestDiscordEmbedFormatting(t *testing.T) {
 
 		if embed.Title != "Reading completed" {
 			t.Fatalf("Title = %q, want %q", embed.Title, "Reading completed")
+		}
+		wantDesc := "New reading saved: https://example.com/article"
+		if embed.Description != wantDesc {
+			t.Fatalf("Description = %q, want %q", embed.Description, wantDesc)
 		}
 		if embed.Color != 0x57F287 {
 			t.Fatalf("Color = %#x, want 0x57F287 (green)", embed.Color)

--- a/internal/notify/discord_test.go
+++ b/internal/notify/discord_test.go
@@ -314,6 +314,133 @@ func TestDiscordEmbedFormatting(t *testing.T) {
 		}
 	})
 
+	t.Run("reading completed new verdict full embed", func(t *testing.T) {
+		embed := discordEmbedForEvent(Event{
+			Type:           EventTaskCompleted,
+			TaskID:         "bf_r1",
+			TaskMode:       "read",
+			TLDR:           "Article explains how transformers work",
+			NoveltyVerdict: "new",
+			Tags:           []string{"ml", "transformers"},
+			Connections: []models.Connection{
+				{ReadingID: "bf_r0", Reason: "Related overview of attention mechanisms"},
+			},
+			Timestamp: time.Now().UTC(),
+		})
+
+		if embed.Title != "Reading completed" {
+			t.Fatalf("Title = %q, want %q", embed.Title, "Reading completed")
+		}
+		if embed.Color != 0x57F287 {
+			t.Fatalf("Color = %#x, want 0x57F287 (green)", embed.Color)
+		}
+		if embed.URL != "" {
+			t.Fatalf("URL = %q, want empty (no PR for readings)", embed.URL)
+		}
+		if !containsField(embed.Fields, "TL;DR", "Article explains how transformers work") {
+			t.Fatalf("fields = %#v, want TL;DR field", embed.Fields)
+		}
+		if !containsField(embed.Fields, "Tags", "ml, transformers") {
+			t.Fatalf("fields = %#v, want Tags field", embed.Fields)
+		}
+		if !containsField(embed.Fields, "Connections", "attention mechanisms") {
+			t.Fatalf("fields = %#v, want Connections field", embed.Fields)
+		}
+		// Should NOT have PR URL field
+		if containsField(embed.Fields, "Pull Request", "") {
+			t.Fatal("reading embed should not have Pull Request field")
+		}
+	})
+
+	t.Run("reading completed nothing new verdict", func(t *testing.T) {
+		embed := discordEmbedForEvent(Event{
+			Type:           EventTaskCompleted,
+			TaskID:         "bf_r2",
+			TaskMode:       "read",
+			TLDR:           "Summarizes transformer architecture basics",
+			NoveltyVerdict: "nothing new",
+			Tags:           []string{"ml"},
+			Connections: []models.Connection{
+				{ReadingID: "bf_r0", Reason: "Covers same attention mechanism overview"},
+			},
+			Timestamp: time.Now().UTC(),
+		})
+
+		if embed.Title != "Reading completed" {
+			t.Fatalf("Title = %q, want %q", embed.Title, "Reading completed")
+		}
+		if embed.Color != 0x95A5A6 {
+			t.Fatalf("Color = %#x, want 0x95A5A6 (grey)", embed.Color)
+		}
+		if !strings.Contains(embed.Description, "Nothing new") {
+			t.Fatalf("Description = %q, want 'Nothing new' language", embed.Description)
+		}
+		if !containsField(embed.Fields, "TL;DR", "transformer architecture") {
+			t.Fatalf("fields = %#v, want TL;DR field", embed.Fields)
+		}
+		if !containsField(embed.Fields, "Most Similar", "attention mechanism") {
+			t.Fatalf("fields = %#v, want Most Similar field with connection reason", embed.Fields)
+		}
+	})
+
+	t.Run("reading completed duplicate verdict", func(t *testing.T) {
+		embed := discordEmbedForEvent(Event{
+			Type:           EventTaskCompleted,
+			TaskID:         "bf_r3",
+			TaskMode:       "read",
+			TLDR:           "Same article about transformers",
+			NoveltyVerdict: "duplicate",
+			Timestamp:      time.Now().UTC(),
+		})
+
+		if embed.Title != "Reading completed" {
+			t.Fatalf("Title = %q, want %q", embed.Title, "Reading completed")
+		}
+		if embed.Color != 0x95A5A6 {
+			t.Fatalf("Color = %#x, want 0x95A5A6 (grey)", embed.Color)
+		}
+		if !strings.Contains(embed.Description, "Already read") {
+			t.Fatalf("Description = %q, want 'Already read' language", embed.Description)
+		}
+		if !containsField(embed.Fields, "TL;DR", "transformers") {
+			t.Fatalf("fields = %#v, want TL;DR field", embed.Fields)
+		}
+		// Should NOT have tags or connections fields for duplicate
+		if containsField(embed.Fields, "Tags", "") {
+			t.Fatal("duplicate embed should not have Tags field")
+		}
+		if containsField(embed.Fields, "Connections", "") {
+			t.Fatal("duplicate embed should not have Connections field")
+		}
+	})
+
+	t.Run("reading failed shows reading-specific title", func(t *testing.T) {
+		embed := discordEmbedForEvent(Event{
+			Type:         EventTaskFailed,
+			TaskID:       "bf_r4",
+			TaskMode:     "read",
+			Message:      "embedding API returned 429",
+			AgentLogTail: "rate limited",
+			Timestamp:    time.Now().UTC(),
+		})
+
+		if embed.Title != "Reading failed" {
+			t.Fatalf("Title = %q, want %q", embed.Title, "Reading failed")
+		}
+		if embed.Color != 0xED4245 {
+			t.Fatalf("Color = %#x, want 0xED4245 (red)", embed.Color)
+		}
+		if !strings.Contains(embed.Description, "Reading") {
+			t.Fatalf("Description = %q, want reading-specific failure message", embed.Description)
+		}
+		if !containsField(embed.Fields, "Failure", "429") {
+			t.Fatalf("fields = %#v, want Failure field", embed.Fields)
+		}
+		if !containsField(embed.Fields, "Log Tail", "rate limited") {
+			t.Fatalf("fields = %#v, want Log Tail field", embed.Fields)
+		}
+	})
+
 	t.Run("running stays concise", func(t *testing.T) {
 		embed := discordEmbedForEvent(Event{
 			Type:      EventTaskRunning,


### PR DESCRIPTION
## Summary

- Replaces the awkward `"Task bf_r1 reading completed."` description in the "new" verdict Discord embed with `"New reading saved: <url>"`, surfacing the reading URL directly in the embed description
- Matches the conversational tone of the sibling "duplicate" (`"Already read this — here's what you captured:"`) and "nothing new" (`"Nothing new here."`) verdicts
- Drops the redundant task ID from the description (already shown in the Task embed field)

## Test plan

- [x] Updated existing `reading completed new verdict full embed` test to assert on the new description text
- [x] `make test` passes