### PR TITLE
Improve "new" verdict description in reading-completed Discord embed

### DIFF
--- a/internal/notify/discord.go
+++ b/internal/notify/discord.go
@@ -348,7 +348,11 @@ func readingCompletedContent(event Event) (string, []discord.EmbedField, int) {
 			}
 			fields = append(fields, discord.EmbedField{Name: "Connections", Value: truncate(strings.Join(lines, "\n"), maxEmbedTextLength), Inline: false})
 		}
-		return fmt.Sprintf("Task %s reading completed.", event.TaskID), fields, 0x57F287
+		desc := "New reading saved."
+		if event.Prompt != "" {
+			desc = fmt.Sprintf("New reading saved: %s", event.Prompt)
+		}
+		return desc, fields, 0x57F287
 	}
 }
 

--- a/internal/notify/discord_test.go
+++ b/internal/notify/discord_test.go
@@ -319,6 +319,7 @@ func TestDiscordEmbedFormatting(t *testing.T) {
 			Type:           EventTaskCompleted,
 			TaskID:         "bf_r1",
 			TaskMode:       "read",
+			Prompt:         "https://example.com/article",
 			TLDR:           "Article explains how transformers work",
 			NoveltyVerdict: "new",
 			Tags:           []string{"ml", "transformers"},
@@ -330,6 +331,10 @@ func TestDiscordEmbedFormatting(t *testing.T) {
 
 		if embed.Title != "Reading completed" {
 			t.Fatalf("Title = %q, want %q", embed.Title, "Reading completed")
+		}
+		wantDesc := "New reading saved: https://example.com/article"
+		if embed.Description != wantDesc {
+			t.Fatalf("Description = %q, want %q", embed.Description, wantDesc)
 		}
 		if embed.Color != 0x57F287 {
 			t.Fatalf("Color = %#x, want 0x57F287 (green)", embed.Color)


### PR DESCRIPTION
Replace the awkward "Task bf_r1 reading completed." with "New reading saved: <url>", which surfaces the URL directly in the embed description and matches the conversational tone of the sibling "duplicate" and "nothing new" verdicts.