### PR TITLE
Guard reading completion against duplicate-URL misclassification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Two goroutines: chi REST API on `:8080` + polling orchestrator (5s default). Thr
 
 - **api/** — chi router, handlers, JSON responses, `LogFetcher` interface, `NewTask` shared task-creation helper (used by both REST handler and Discord modal), `CancelTask` and `RetryTask` shared action helpers (used by both REST handler and Discord)
 - **orchestrator/** — Poll loop (`orchestrator.go`), dispatch (`dispatch.go`), monitoring (`monitor.go`, including `handleReadingCompletion` for read-mode tasks), recovery (`recovery.go`), local mode (`local.go`). Subpackages: `docker/` (Docker container management via SSM or local exec), `ec2/` (EC2 lifecycle, auto-scaler, spot interruption handler), `fargate/` (ECS/Fargate runner, CloudWatch log parsing), `s3/` (agent output upload)
-- **store/** — `Store` interface + PostgreSQL (`pgxpool`, goose migrations). Includes `CreateReading` / `UpsertReading` for the `readings` table.
+- **store/** — `Store` interface + PostgreSQL (`pgxpool`, goose migrations). Includes `CreateReading` / `UpsertReading` / `GetReadingByURL` for the `readings` table.
 - **models/** — `Task`, `Instance`, `AllowedSender`, `DiscordInstall`, and `Reading` (+ `Connection`) structs with status enums. `Task.AgentImage` records which Docker image the orchestrator used (read tasks get `ReaderImage`, others get the default agent image). `FindFirstURL` / `InferReviewMode` auto-detect review mode when a prompt's first URL is a GitHub PR URL.
 - **embeddings/** — Thin `Embedder` interface (`Embed(ctx, text) ([]float32, error)`) with an `OpenAIEmbedder` HTTP client (no SDK). Used by the orchestrator to embed a reading's final TL;DR before writing the `readings` row.
 - **discord/** — Discord interaction handler (Ed25519 signature verification, PING/PONG, interaction routing, `/backflow create` modal for task creation, `/backflow read <url> [force]` for reading-mode task creation, `/backflow cancel` and `/backflow retry` commands, button click handling). `HandlerActions` struct groups callback functions and role-based authorization config.
@@ -134,11 +134,13 @@ When a task's `task_mode` is `read`, the orchestrator selects `BACKFLOW_READER_I
 On completion, the orchestrator's `handleReadingCompletion` helper (in `internal/orchestrator/monitor.go`) runs synchronously:
 
 1. Parses the reading-specific fields off `ContainerStatus`.
-2. Calls `embeddings.Embedder.Embed(ctx, tldr)` to embed the final TL;DR (re-embedded by the orchestrator, not reused from the agent — the agent's draft TL;DR can be refined after similarity lookup).
-3. Writes the row via `store.CreateReading`, or `store.UpsertReading` when `task.Force == true`.
-4. Emits `task.completed` with `WithReading(tldr, verdict, tags, connections)`.
+2. If the agent's `novelty_verdict` is `"duplicate"` and `!task.Force`, short-circuits with no write.
+3. Otherwise, when `!task.Force`, calls `store.GetReadingByURL(ctx, url)` as an independent duplicate check. The agent's verdict is advisory — if the URL already exists, the task fails with a "reading already exists" error rather than overwriting. This guards against the agent misclassifying a previously-read URL as `"novel"`.
+4. Calls `embeddings.Embedder.Embed(ctx, tldr)` to embed the final TL;DR (re-embedded by the orchestrator, not reused from the agent — the agent's draft TL;DR can be refined after similarity lookup).
+5. Writes the row via `store.CreateReading` when `!task.Force`, or `store.UpsertReading` when `task.Force == true`.
+6. Emits `task.completed` with `WithReading(tldr, verdict, tags, connections)`.
 
-If the embedding API call or the DB write fails, the task is marked `failed` rather than silently `completed`, and `task.failed` is emitted. If `embedder` is nil (no `OPENAI_API_KEY` configured), reading tasks fail at completion.
+If the embedding API call, DB lookup, or DB write fails, the task is marked `failed` rather than silently `completed`, and `task.failed` is emitted. If `embedder` is nil (no `OPENAI_API_KEY` configured), reading tasks fail at completion.
 
 The reading agent image and reader-side shell scripts live in `docker/reader/`:
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,3 +1,10 @@
 # HANDOFF.md
 
 Ledger of cross-PR tradeoffs. Each entry: decision → consequence for downstream work.
+
+## Duplicate-URL handling in `handleReadingCompletion`
+
+- **Orchestrator treats the agent's `novelty_verdict` as advisory, not authoritative.** The reader agent runs `read-lookup.sh` during its turn, but LLMs occasionally skip the lookup step and return `novel` / `extends_existing` for a URL that already exists. The orchestrator now calls `store.GetReadingByURL` itself before embedding. If the URL is already stored and `task.Force` is false, the task fails with `"reading already exists for url ... (id=...); resubmit with force=true to overwrite"`. If `task.Force` is true, the existing row is overwritten via `UpsertReading`.
+- **`CreateReading` vs `UpsertReading` split by `Force`.** Non-forced writes go through `CreateReading` (the pre-insert duplicate check guarantees no conflict; if a race beats us to it, the unique index on `url` surfaces the error). Forced writes continue through `UpsertReading`.
+- **`GetReadingByURL` added to `Store`.** Selects all columns except `embedding`. The embedding vector is expensive to transport; if a future caller needs it, fetch by id or add a targeted accessor.
+- **API still lacks a `force` wire field.** The Discord `/backflow read` command already accepts `force` (default false). REST callers cannot set `Force` until the create endpoint is extended.

--- a/internal/messaging/inbound_test.go
+++ b/internal/messaging/inbound_test.go
@@ -95,8 +95,11 @@ func (m *mockStore) UpsertDiscordTaskThread(context.Context, *models.DiscordTask
 func (m *mockStore) GetDiscordTaskThread(context.Context, string) (*models.DiscordTaskThread, error) {
 	return nil, store.ErrNotFound
 }
-func (m *mockStore) CreateReading(context.Context, *models.Reading) error       { return nil }
-func (m *mockStore) UpsertReading(context.Context, *models.Reading) error       { return nil }
+func (m *mockStore) CreateReading(context.Context, *models.Reading) error { return nil }
+func (m *mockStore) UpsertReading(context.Context, *models.Reading) error { return nil }
+func (m *mockStore) GetReadingByURL(context.Context, string) (*models.Reading, error) {
+	return nil, store.ErrNotFound
+}
 func (m *mockStore) WithTx(_ context.Context, fn func(store.Store) error) error { return fn(m) }
 func (m *mockStore) Close() error                                               { return nil }
 

--- a/internal/orchestrator/ec2/spot_test.go
+++ b/internal/orchestrator/ec2/spot_test.go
@@ -107,8 +107,11 @@ func (s *interruptionStore) UpsertDiscordTaskThread(context.Context, *models.Dis
 func (s *interruptionStore) GetDiscordTaskThread(context.Context, string) (*models.DiscordTaskThread, error) {
 	return nil, store.ErrNotFound
 }
-func (s *interruptionStore) CreateReading(context.Context, *models.Reading) error       { return nil }
-func (s *interruptionStore) UpsertReading(context.Context, *models.Reading) error       { return nil }
+func (s *interruptionStore) CreateReading(context.Context, *models.Reading) error { return nil }
+func (s *interruptionStore) UpsertReading(context.Context, *models.Reading) error { return nil }
+func (s *interruptionStore) GetReadingByURL(context.Context, string) (*models.Reading, error) {
+	return nil, store.ErrNotFound
+}
 func (s *interruptionStore) WithTx(_ context.Context, fn func(store.Store) error) error { return fn(s) }
 func (s *interruptionStore) Close() error                                               { return nil }
 

--- a/internal/orchestrator/helpers_test.go
+++ b/internal/orchestrator/helpers_test.go
@@ -35,16 +35,21 @@ type mockStore struct {
 	listInstancesErr       error
 	createReadingErr       error
 	upsertReadingErr       error
+	getReadingByURLErr     error
 
 	// Recorded reading calls.
 	createdReadings  []models.Reading
 	upsertedReadings []models.Reading
+
+	// Pre-seeded readings for GetReadingByURL lookups, keyed by URL.
+	readingsByURL map[string]*models.Reading
 }
 
 func newMockStore() *mockStore {
 	return &mockStore{
-		tasks:     make(map[string]*models.Task),
-		instances: make(map[string]*models.Instance),
+		tasks:         make(map[string]*models.Task),
+		instances:     make(map[string]*models.Instance),
+		readingsByURL: make(map[string]*models.Reading),
 	}
 }
 
@@ -358,6 +363,8 @@ func (s *mockStore) CreateReading(_ context.Context, r *models.Reading) error {
 	}
 	cp := *r
 	s.createdReadings = append(s.createdReadings, cp)
+	stored := cp
+	s.readingsByURL[r.URL] = &stored
 	return nil
 }
 
@@ -369,7 +376,23 @@ func (s *mockStore) UpsertReading(_ context.Context, r *models.Reading) error {
 	}
 	cp := *r
 	s.upsertedReadings = append(s.upsertedReadings, cp)
+	stored := cp
+	s.readingsByURL[r.URL] = &stored
 	return nil
+}
+
+func (s *mockStore) GetReadingByURL(_ context.Context, url string) (*models.Reading, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.getReadingByURLErr != nil {
+		return nil, s.getReadingByURLErr
+	}
+	r, ok := s.readingsByURL[url]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	cp := *r
+	return &cp, nil
 }
 
 func (s *mockStore) Close() error { return nil }

--- a/internal/orchestrator/monitor.go
+++ b/internal/orchestrator/monitor.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -200,6 +201,21 @@ func (o *Orchestrator) handleReadingCompletion(ctx context.Context, task *models
 		return notify.WithReading(status.TLDR, status.NoveltyVerdict, status.Tags, status.Connections), nil
 	}
 
+	// Independent DB duplicate check. The agent's self-reported novelty_verdict
+	// is advisory — it can misclassify a previously-read URL as "novel" if it
+	// skipped the lookup step. The orchestrator is the source of truth for
+	// "does this URL already exist?", so re-check here before spending an
+	// embedding API call and potentially overwriting the existing row.
+	if !task.Force {
+		existing, err := o.store.GetReadingByURL(ctx, url)
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("lookup reading by url: %w", err)
+		}
+		if existing != nil {
+			return nil, fmt.Errorf("reading already exists for url %q (id=%s); resubmit with force=true to overwrite", url, existing.ID)
+		}
+	}
+
 	vec, err := o.embedder.Embed(ctx, status.TLDR)
 	if err != nil {
 		return nil, fmt.Errorf("embed tldr: %w", err)
@@ -228,8 +244,18 @@ func (o *Orchestrator) handleReadingCompletion(ctx context.Context, task *models
 		CreatedAt:      time.Now().UTC(),
 	}
 
-	if err := o.store.UpsertReading(ctx, reading); err != nil {
-		return nil, fmt.Errorf("upsert reading: %w", err)
+	// Force=true intentionally overwrites any existing row (by url unique index).
+	// Force=false is guaranteed to be a new URL by the duplicate check above,
+	// so CreateReading is sufficient — and if a race snuck a row in between the
+	// check and this insert, the unique constraint will surface that as an error.
+	if task.Force {
+		if err := o.store.UpsertReading(ctx, reading); err != nil {
+			return nil, fmt.Errorf("upsert reading: %w", err)
+		}
+	} else {
+		if err := o.store.CreateReading(ctx, reading); err != nil {
+			return nil, fmt.Errorf("create reading: %w", err)
+		}
 	}
 
 	return notify.WithReading(status.TLDR, status.NoveltyVerdict, status.Tags, status.Connections), nil

--- a/internal/orchestrator/monitor_test.go
+++ b/internal/orchestrator/monitor_test.go
@@ -484,12 +484,15 @@ func TestHandleCompletion_ReadSuccess_EmbedsAndCreatesReading(t *testing.T) {
 	}
 	emb.mu.Unlock()
 
-	// UpsertReading received the reading (always upsert, regardless of force).
+	// CreateReading received the reading (non-forced success path: insert only).
 	s.mu.Lock()
-	if len(s.upsertedReadings) != 1 {
-		t.Fatalf("upsertedReadings = %d, want 1", len(s.upsertedReadings))
+	if len(s.createdReadings) != 1 {
+		t.Fatalf("createdReadings = %d, want 1", len(s.createdReadings))
 	}
-	r := s.upsertedReadings[0]
+	if len(s.upsertedReadings) != 0 {
+		t.Fatalf("upsertedReadings = %d, want 0 (non-forced inserts should use CreateReading)", len(s.upsertedReadings))
+	}
+	r := s.createdReadings[0]
 	s.mu.Unlock()
 
 	if r.URL != "https://example.com/post" {
@@ -584,13 +587,13 @@ func TestHandleCompletion_ReadSuccess_AssignsUniqueReadingIDs(t *testing.T) {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if len(s.upsertedReadings) != 2 {
-		t.Fatalf("upsertedReadings = %d, want 2", len(s.upsertedReadings))
+	if len(s.createdReadings) != 2 {
+		t.Fatalf("createdReadings = %d, want 2", len(s.createdReadings))
 	}
-	if s.upsertedReadings[0].ID == s.upsertedReadings[1].ID {
-		t.Errorf("reading IDs collided: %q == %q", s.upsertedReadings[0].ID, s.upsertedReadings[1].ID)
+	if s.createdReadings[0].ID == s.createdReadings[1].ID {
+		t.Errorf("reading IDs collided: %q == %q", s.createdReadings[0].ID, s.createdReadings[1].ID)
 	}
-	for i, r := range s.upsertedReadings {
+	for i, r := range s.createdReadings {
 		if !strings.HasPrefix(r.ID, "bf_") {
 			t.Errorf("reading[%d].ID = %q, want bf_-prefixed", i, r.ID)
 		}
@@ -760,7 +763,7 @@ func TestHandleCompletion_ReadDuplicate_Force_StillWrites(t *testing.T) {
 
 func TestHandleCompletion_ReadStoreFailure_MarksTaskFailed(t *testing.T) {
 	s := newMockStore()
-	s.upsertReadingErr = fmt.Errorf("db write failed")
+	s.createReadingErr = fmt.Errorf("db write failed")
 	now := time.Now().UTC()
 
 	s.CreateInstance(context.Background(), newLocalInstance())
@@ -891,6 +894,144 @@ func TestHandleCompletion_ReadForce_CallsUpsertReading(t *testing.T) {
 	}
 	if s.upsertedReadings[0].URL != "https://example.com/post" {
 		t.Errorf("upserted URL = %q", s.upsertedReadings[0].URL)
+	}
+	if len(s.createdReadings) != 0 {
+		t.Errorf("createdReadings = %d, want 0 (forced writes should go through UpsertReading)", len(s.createdReadings))
+	}
+}
+
+// TestHandleCompletion_ReadExistingURL_NonForce_FailsTask covers the bug where
+// the agent misclassifies a previously-read URL as "novel". The orchestrator
+// must independently check the DB for the URL and fail the task rather than
+// overwriting the existing reading row.
+func TestHandleCompletion_ReadExistingURL_NonForce_FailsTask(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+
+	s.CreateInstance(context.Background(), newLocalInstance())
+
+	// Seed an existing reading for this URL.
+	s.readingsByURL["https://example.com/post"] = &models.Reading{
+		ID:             "bf_existing",
+		TaskID:         "bf_prev",
+		URL:            "https://example.com/post",
+		Title:          "Existing",
+		TLDR:           "already captured",
+		NoveltyVerdict: "novel",
+	}
+
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_read_dup_bug",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeRead,
+		Force:       false,
+		Prompt:      "https://example.com/post",
+		InstanceID:  "local",
+		ContainerID: "cont1",
+		StartedAt:   &now,
+	})
+
+	bus, n := newTestBus()
+	emb := &mockEmbedder{vector: []float32{0.1}}
+	o := newTestOrchestrator(s, bus, withEmbedder(emb))
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_read_dup_bug")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:           true,
+		Complete:       true,
+		TaskMode:       models.TaskModeRead,
+		URL:            "https://example.com/post",
+		TLDR:           "fresh-looking summary",
+		NoveltyVerdict: "novel",
+	})
+	bus.Close()
+
+	got, _ := s.GetTask(context.Background(), "bf_read_dup_bug")
+	if got.Status != models.TaskStatusFailed {
+		t.Errorf("task.Status = %q, want failed (duplicate URL, non-forced)", got.Status)
+	}
+	if got.Error == "" {
+		t.Error("expected non-empty task.Error when non-forced task re-reads existing URL")
+	}
+
+	s.mu.Lock()
+	if len(s.createdReadings) != 0 {
+		t.Errorf("createdReadings = %d, want 0 (no write when URL already exists and !Force)", len(s.createdReadings))
+	}
+	if len(s.upsertedReadings) != 0 {
+		t.Errorf("upsertedReadings = %d, want 0 (no write when URL already exists and !Force)", len(s.upsertedReadings))
+	}
+	s.mu.Unlock()
+
+	// Embedder must not be called — no need to spend money embedding a known URL.
+	emb.mu.Lock()
+	if len(emb.calls) != 0 {
+		t.Errorf("embedder calls = %v, want none when duplicate is detected pre-embed", emb.calls)
+	}
+	emb.mu.Unlock()
+
+	events := n.eventTypes()
+	if len(events) != 1 || events[0] != notify.EventTaskFailed {
+		t.Errorf("events = %v, want [task.failed]", events)
+	}
+}
+
+// TestHandleCompletion_ReadExistingURL_Force_UpsertsOverExisting verifies that
+// when Force is true, an existing URL does NOT fail the task — it proceeds
+// through the upsert path and overwrites the existing row.
+func TestHandleCompletion_ReadExistingURL_Force_UpsertsOverExisting(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+
+	s.CreateInstance(context.Background(), newLocalInstance())
+
+	s.readingsByURL["https://example.com/post"] = &models.Reading{
+		ID:     "bf_existing",
+		TaskID: "bf_prev",
+		URL:    "https://example.com/post",
+		Title:  "Existing",
+		TLDR:   "old summary",
+	}
+
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_read_force_dup",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeRead,
+		Force:       true,
+		Prompt:      "https://example.com/post",
+		InstanceID:  "local",
+		ContainerID: "cont1",
+		StartedAt:   &now,
+	})
+
+	bus, _ := newTestBus()
+	emb := &mockEmbedder{vector: []float32{0.9}}
+	o := newTestOrchestrator(s, bus, withEmbedder(emb))
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_read_force_dup")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:     true,
+		Complete: true,
+		TaskMode: models.TaskModeRead,
+		URL:      "https://example.com/post",
+		TLDR:     "refreshed summary",
+	})
+	bus.Close()
+
+	got, _ := s.GetTask(context.Background(), "bf_read_force_dup")
+	if got.Status != models.TaskStatusCompleted {
+		t.Errorf("task.Status = %q, want completed (Force=true allows overwrite)", got.Status)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.upsertedReadings) != 1 {
+		t.Fatalf("upsertedReadings = %d, want 1", len(s.upsertedReadings))
+	}
+	if s.upsertedReadings[0].TLDR != "refreshed summary" {
+		t.Errorf("upserted TLDR = %q, want refreshed summary", s.upsertedReadings[0].TLDR)
 	}
 }
 

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -669,3 +669,43 @@ func (s *PostgresStore) UpsertReading(ctx context.Context, r *models.Reading) er
 			embedding       = EXCLUDED.embedding`, args...)
 	return err
 }
+
+// GetReadingByURL returns the reading row whose url column matches exactly.
+// Returns ErrNotFound when no row matches. The embedding column is intentionally
+// not selected — callers that need it should fetch by id with a dedicated query.
+func (s *PostgresStore) GetReadingByURL(ctx context.Context, url string) (*models.Reading, error) {
+	row := s.q.QueryRow(ctx, `
+		SELECT id, task_id, url, title, tldr,
+		       tags, keywords, people, orgs,
+		       novelty_verdict, connections, summary, raw_output,
+		       created_at
+		FROM readings
+		WHERE url = $1`, url)
+
+	var (
+		r              models.Reading
+		connectionsRaw []byte
+		rawOutput      []byte
+	)
+	err := row.Scan(
+		&r.ID, &r.TaskID, &r.URL, &r.Title, &r.TLDR,
+		&r.Tags, &r.Keywords, &r.People, &r.Orgs,
+		&r.NoveltyVerdict, &connectionsRaw, &r.Summary, &rawOutput,
+		&r.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if len(connectionsRaw) > 0 {
+		if err := json.Unmarshal(connectionsRaw, &r.Connections); err != nil {
+			return nil, fmt.Errorf("unmarshal connections: %w", err)
+		}
+	}
+	if len(rawOutput) > 0 {
+		r.RawOutput = rawOutput
+	}
+	return &r, nil
+}

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -1318,6 +1318,64 @@ func TestPG_UpsertReading_Update(t *testing.T) {
 	}
 }
 
+func TestPG_GetReadingByURL(t *testing.T) {
+	s := testPostgresStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	task := pgTestTask(t, s)
+
+	embedding := make([]float32, 1536)
+	embedding[0] = 0.42
+
+	seeded := &models.Reading{
+		ID:             "bf_READ_LOOKUP",
+		TaskID:         task.ID,
+		URL:            "https://example.com/lookup",
+		Title:          "Lookup Target",
+		TLDR:           "exact-url lookup",
+		Tags:           []string{"lookup"},
+		Keywords:       []string{},
+		People:         []string{},
+		Orgs:           []string{},
+		NoveltyVerdict: "novel",
+		Connections:    []models.Connection{},
+		Summary:        "",
+		RawOutput:      []byte(`{}`),
+		Embedding:      embedding,
+		CreatedAt:      now,
+	}
+	if err := s.CreateReading(ctx, seeded); err != nil {
+		t.Fatalf("CreateReading: %v", err)
+	}
+
+	// Hit: exact URL match returns the seeded row.
+	got, err := s.GetReadingByURL(ctx, "https://example.com/lookup")
+	if err != nil {
+		t.Fatalf("GetReadingByURL (hit): %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetReadingByURL: returned nil reading for hit")
+	}
+	if got.ID != seeded.ID {
+		t.Errorf("ID = %q, want %q", got.ID, seeded.ID)
+	}
+	if got.URL != seeded.URL {
+		t.Errorf("URL = %q, want %q", got.URL, seeded.URL)
+	}
+	if got.Title != seeded.Title {
+		t.Errorf("Title = %q, want %q", got.Title, seeded.Title)
+	}
+	if got.TLDR != seeded.TLDR {
+		t.Errorf("TLDR = %q, want %q", got.TLDR, seeded.TLDR)
+	}
+
+	// Miss: unknown URL returns ErrNotFound.
+	_, err = s.GetReadingByURL(ctx, "https://example.com/does-not-exist")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetReadingByURL (miss) err = %v, want ErrNotFound", err)
+	}
+}
+
 func TestPG_MatchReadings_SimilarityOrdering(t *testing.T) {
 	s := testPostgresStore(t)
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -82,6 +82,7 @@ type Store interface {
 	// Readings
 	CreateReading(ctx context.Context, r *models.Reading) error
 	UpsertReading(ctx context.Context, r *models.Reading) error
+	GetReadingByURL(ctx context.Context, url string) (*models.Reading, error)
 
 	// Transactions
 	WithTx(ctx context.Context, fn func(Store) error) error


### PR DESCRIPTION
## Summary

The reader agent's `novelty_verdict` is self-reported and advisory: the prompt asks it to run `read-lookup.sh` and set `"duplicate"` for URLs already in the DB, but LLMs drop that step and return `"novel"` for pages that look fresh on re-fetch. The orchestrator used to trust that verdict and `UpsertReading`, which on `ON CONFLICT (url) DO UPDATE` silently overwrote the previous reading row — the user sees "New reading saved" with `"novel"` verdict in Discord even though the URL was captured before, and the richer previous content is destroyed.

**Fix:** `handleReadingCompletion` now independently looks up the URL in the DB before embedding.
- If the URL already exists and `!task.Force`, the task fails with `"reading already exists for url ... (id=...); resubmit with force=true to overwrite"`. No embed API call, no DB write.
- If `task.Force == true`, the existing row is overwritten via `UpsertReading` (same as before).
- Non-forced inserts now go through `CreateReading`, matching the behavior documented in CLAUDE.md. The unique index on `readings.url` provides a second line of defense if a race squeezes a row in between the lookup and the insert.

Also adds `Store.GetReadingByURL` for the duplicate check — returns all reading columns except `embedding` (expensive to transport; add a targeted accessor later if needed) — and updates the four mock `Store` implementations (`mockStore` in orchestrator/messaging, `interruptionStore` in ec2) to satisfy the interface.

## Test plan

Written with TDD (red → green):

- [x] `TestPG_GetReadingByURL` — exact-URL hit returns row, miss returns `ErrNotFound`
- [x] `TestHandleCompletion_ReadExistingURL_NonForce_FailsTask` — seeded duplicate, agent says `"novel"`, `Force=false` → task fails, no embedder call, no write, `task.failed` event emitted
- [x] `TestHandleCompletion_ReadExistingURL_Force_UpsertsOverExisting` — seeded duplicate, `Force=true` → task completes, upsert overwrites the existing row
- [x] Updated `TestHandleCompletion_ReadSuccess_EmbedsAndCreatesReading` and `TestHandleCompletion_ReadSuccess_AssignsUniqueReadingIDs` to assert `createdReadings` (not `upsertedReadings`) for the non-forced success path
- [x] Updated `TestHandleCompletion_ReadStoreFailure_MarksTaskFailed` to inject `createReadingErr` (now exercises the insert path)
- [x] Updated `TestHandleCompletion_ReadForce_CallsUpsertReading` to also assert `createdReadings == 0`
- [x] `make test` — all 15 package suites pass
- [x] `make lint` — clean

## Notes

- API still lacks a `force` wire field. The Discord `/backflow read` command already accepts `force` (default false). REST callers cannot set `Force` until the create endpoint is extended — tracked in HANDOFF.md for a follow-up.
- Docs updated: CLAUDE.md reading-mode section lists the new step ordering and explains the `CreateReading` vs `UpsertReading` split; HANDOFF.md records the tradeoffs.